### PR TITLE
The different behaviour for RMB and double-click in similar elements #2

### DIFF
--- a/src/main/java/io/openbpm/control/mapper/IncidentMapper.java
+++ b/src/main/java/io/openbpm/control/mapper/IncidentMapper.java
@@ -22,7 +22,6 @@ public abstract class IncidentMapper {
     @Mapping(target = "type", source = "incidentType")
     @Mapping(target = "message", source = "incidentMessage")
     @Mapping(target = "incidentId", source = "id")
-    @Mapping(target = "id", ignore = true)
     @Mapping(target = "timestamp", source = "incidentTimestamp")
     public abstract IncidentData fromIncidentModel(IncidentDto source);
 
@@ -30,7 +29,6 @@ public abstract class IncidentMapper {
         return metadata.create(IncidentData.class);
     }
 
-    @Mapping(target = "id", ignore = true)
     @Mapping(target = "type", source = "incidentType")
     @Mapping(target = "message", source = "incidentMessage")
     @Mapping(target = "incidentId", source = "id")

--- a/src/main/java/io/openbpm/control/view/processinstance/ProcessInstanceListView.java
+++ b/src/main/java/io/openbpm/control/view/processinstance/ProcessInstanceListView.java
@@ -95,8 +95,6 @@ public class ProcessInstanceListView extends StandardListView<ProcessInstanceDat
     protected Notifications notifications;
     @Autowired
     protected DialogWindows dialogWindows;
-    @Autowired
-    protected ComponentHelper componentHelper;
     @ViewComponent
     protected UrlQueryParametersFacet urlQueryParameters;
     @ViewComponent

--- a/src/main/resources/io/openbpm/control/view/alltasks/all-tasks-view.xml
+++ b/src/main/resources/io/openbpm/control/view/alltasks/all-tasks-view.xml
@@ -93,6 +93,11 @@
                                 type="list_itemTracking"/>
                         <action id="reassignTask" text="msg://reassignTask" icon="RETWEET"
                                 type="list_itemTracking"/>
+                        <action id="view" type="list_edit" visible="false">
+                            <properties>
+                                <property name="openMode" value="DIALOG"/>
+                            </properties>
+                        </action>
                     </actions>
                     <columns resizable="true">
                         <column property="taskDefinitionKey" autoWidth="true" sortable="false">

--- a/src/main/resources/io/openbpm/control/view/bpmengine/bpm-engine-list-view.xml
+++ b/src/main/resources/io/openbpm/control/view/bpmengine/bpm-engine-list-view.xml
@@ -41,10 +41,10 @@
                   dataContainer="bpmEnginesDc"
                   columnReorderingAllowed="true">
             <actions>
-                <action id="create" type="list_create"/>
-                <action id="edit" type="list_edit"/>
-                <action id="remove" type="list_remove"/>
                 <action id="refresh" type="list_refresh"/>
+                <action id="create" type="list_create"/>
+                <action id="remove" type="list_remove"/>
+                <action id="edit" type="list_edit" visible="false"/>
             </actions>
             <columns resizable="true">
                 <column property="name">

--- a/src/main/resources/io/openbpm/control/view/incidentdata/incident-data-list-view.xml
+++ b/src/main/resources/io/openbpm/control/view/incidentdata/incident-data-list-view.xml
@@ -36,6 +36,7 @@
             <actions>
                 <action id="refresh" type="list_refresh"/>
                 <action id="bulkRetry" type="list_itemTracking" icon="ROTATE_LEFT" text="msg:///actions.Retry"/>
+                <action id="view" type="list_edit" visible="false"/>
             </actions>
             <columns resizable="true">
                 <column property="activityId"/>

--- a/src/main/resources/io/openbpm/control/view/processdefinition/process-definition-list-view.xml
+++ b/src/main/resources/io/openbpm/control/view/processdefinition/process-definition-list-view.xml
@@ -11,7 +11,6 @@
             <loader id="processDefinitionsDl"/>
         </collection>
         <instance id="processDefinitionFilterDc" class="io.openbpm.control.entity.filter.ProcessDefinitionFilter"/>
-
     </data>
     <facets>
         <urlQueryParameters>
@@ -20,9 +19,6 @@
     </facets>
     <actions>
         <action id="applyFilter" text="msg:///actions.Apply" icon="SEARCH"/>
-        <action id="bulkRemove" text="msg://processDefinitionList.remove" icon="TRASH" actionVariant="DANGER"/>
-        <action id="bulkSuspend" text="msg://processDefinitionList.suspend" icon="PAUSE"/>
-        <action id="bulkActivate" text="msg://processDefinitionList.activate" icon="PLAY"/>
     </actions>
     <layout>
         <hbox id="filterPanel" width="100%" padding="true" spacing="false">
@@ -61,13 +57,12 @@
             </details>
         </hbox>
 
-
         <hbox id="buttonsPanel" classNames="buttons-panel">
             <button id="refreshBtn" action="processDefinitionsGrid.refresh" themeNames="primary success"/>
-            <button id="deployBtn" icon="ROCKET" text="msg://processDefinitionList.uploadBpmnXml"/>
-            <button id="bulkDeleteBtn" action="bulkRemove" enabled="false"/>
-            <button id="bulkActivateBtn" action="bulkActivate" enabled="false"/>
-            <button id="bulkSuspendBtn" action="bulkSuspend" enabled="false"/>
+            <button id="deployBtn" action="processDefinitionsGrid.deploy"/>
+            <button id="bulkRemoveBtn" action="processDefinitionsGrid.bulkRemove"/>
+            <button id="bulkActivateBtn" action="processDefinitionsGrid.bulkActivate"/>
+            <button id="bulkSuspendBtn" action="processDefinitionsGrid.bulkSuspend"/>
             <simplePagination id="processDefinitionPagination" dataLoader="processDefinitionsDl" autoLoad="true"
                               alignSelf="END"/>
         </hbox>
@@ -79,12 +74,21 @@
                   selectionMode="MULTI">
             <actions>
                 <action id="refresh" type="list_refresh"/>
+                <action id="deploy" icon="ROCKET" text="msg://processDefinitionList.uploadBpmnXml"/>
+                <action id="bulkRemove" type="list_itemTracking" text="msg://processDefinitionList.remove" icon="TRASH"
+                        actionVariant="DANGER"/>
+                <action id="bulkActivate" type="list_itemTracking" text="msg://processDefinitionList.activate"
+                        icon="PLAY"/>
+                <action id="bulkSuspend" type="list_itemTracking" text="msg://processDefinitionList.suspend"
+                        icon="PAUSE"/>
+                <action id="view" type="list_edit" visible="false"/>
             </actions>
             <columns resizable="true">
                 <column property="name" flexGrow="3"/>
                 <column property="key" flexGrow="2"/>
                 <column property="version" autoWidth="true" flexGrow="1"/>
-                <column key="status" header="msg://processDefinitionList.status" autoWidth="true" sortable="false" flexGrow="1"/>
+                <column key="status" header="msg://processDefinitionList.status" autoWidth="true" sortable="false"
+                        flexGrow="1"/>
                 <column key="actions" sortable="false" editable="false" autoWidth="true" flexGrow="0"/>
             </columns>
         </dataGrid>

--- a/src/main/resources/io/openbpm/control/view/processinstance/process-instance-list-view.xml
+++ b/src/main/resources/io/openbpm/control/view/processinstance/process-instance-list-view.xml
@@ -37,11 +37,11 @@
                   width="100%" selectionMode="MULTI"
                   minHeight="20em">
             <actions>
-                <action id="view" type="list_read"/>
                 <action id="refresh" type="list_refresh"/>
                 <action id="bulkTerminate" type="list_itemTracking" text="msg:///actions.Terminate" icon="DOT_CIRCLE"/>
                 <action id="bulkActivate" type="list_itemTracking" text="msg:///actions.Activate" icon="PLAY"/>
                 <action id="bulkSuspend" type="list_itemTracking" text="msg:///actions.Suspend" icon="PAUSE"/>
+                <action id="view" type="list_edit" visible="false"/>
             </actions>
             <columns resizable="true">
                 <column property="id" flexGrow="1"/>


### PR DESCRIPTION
1. ProcessDefinitionListView: add "Deploy", "Activate", "Suspend" actions to DataGrid context menu, add opening an editor on double-click
2. ProcessInstanceListView: hide "View" action in DataGrid context menu
3. AllTasksView, IncidentDataListView: add opening an editor on double-click