### PR TITLE
Process(es) not deployed: this notification should be more informative #43

### DIFF
--- a/src/main/frontend/themes/openbpm-control/openbpm-control.css
+++ b/src/main/frontend/themes/openbpm-control/openbpm-control.css
@@ -55,3 +55,12 @@ vaadin-grid::part(multiline-text-cell) {
 vaadin-grid::part(error-cell) {
     background-color: var(--lumo-error-color-10pct);
 }
+
+vaadin-button[theme~='badge'][theme~='has-icon'] {
+    padding-block: 0.2em;
+}
+
+vaadin-button[theme~='badge'][theme~='has-icon'] vaadin-icon {
+    margin-left: 0;
+    margin-block: 0;
+}

--- a/src/main/java/io/openbpm/control/action/CopyEntityPropertyToClipboardAction.java
+++ b/src/main/java/io/openbpm/control/action/CopyEntityPropertyToClipboardAction.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.action;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import io.jmix.core.Messages;
+import io.jmix.core.entity.EntityValues;
+import io.jmix.flowui.Notifications;
+import io.jmix.flowui.action.ActionType;
+import io.jmix.flowui.component.UiComponentUtils;
+import io.jmix.flowui.fragment.Fragment;
+import io.jmix.flowui.fragment.FragmentData;
+import io.jmix.flowui.fragment.FragmentUtils;
+import io.jmix.flowui.kit.action.BaseAction;
+import io.jmix.flowui.kit.component.ComponentUtils;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.model.ViewData;
+import io.jmix.flowui.view.View;
+import io.jmix.flowui.view.ViewControllerUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ActionType(CopyEntityPropertyToClipboardAction.ID)
+public class CopyEntityPropertyToClipboardAction extends BaseAction {
+
+    public static final String ID = "control_copyEntityPropertyToClipboard";
+
+    protected Messages messages;
+    protected Notifications notifications;
+
+    protected String dataContainer;
+    protected String property;
+
+    protected InstanceContainer<?> instanceContainer;
+
+    public CopyEntityPropertyToClipboardAction() {
+        super(ID);
+    }
+
+    public CopyEntityPropertyToClipboardAction(String id) {
+        super(id);
+
+        this.icon = ComponentUtils.convertToIcon(VaadinIcon.COPY);
+    }
+
+    @Autowired
+    public void setMessages(Messages messages) {
+        this.messages = messages;
+
+        this.text = messages.getMessage("actions.Copy");
+    }
+
+    @Autowired
+    public void setNotifications(Notifications notifications) {
+        this.notifications = notifications;
+    }
+
+    public void setDataContainer(String dataContainer) {
+        this.dataContainer = dataContainer;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+
+    public void setInstanceContainer(InstanceContainer<?> instanceContainer) {
+        this.instanceContainer = instanceContainer;
+    }
+
+    @Override
+    public void actionPerform(Component component) {
+        InstanceContainer<?> container = getInstanceContainer(component);
+
+        Object item = container.getItem();
+        Object propertyValue = EntityValues.getValue(item, property);
+        String valueAsString = propertyValue != null ? propertyValue.toString() : "";
+
+
+        UiComponentUtils.copyToClipboard(valueAsString)
+                .then(successResult -> notifications.create(
+                                        messages.getMessage(getClass(), "copyComponentValueAction.copied"))
+                                .withPosition(Notification.Position.TOP_END)
+                                .withThemeVariant(NotificationVariant.LUMO_SUCCESS)
+                                .show(),
+                        errorResult -> notifications.create(
+                                        messages.getMessage(getClass(), "copyComponentValueAction.copyFailed"))
+                                .withPosition(Notification.Position.TOP_END)
+                                .withThemeVariant(NotificationVariant.LUMO_ERROR)
+                                .show());
+    }
+
+    protected InstanceContainer<?> getInstanceContainer(Component component) {
+        if (instanceContainer == null) {
+            Fragment<?> fragment = UiComponentUtils.findFragment(component);
+
+            if (fragment != null) {
+                FragmentData fragmentData = FragmentUtils.getFragmentData(fragment);
+                instanceContainer = fragmentData.getContainer(dataContainer);
+
+            } else {
+                View<?> view = UiComponentUtils.findView(component);
+                if (view == null) {
+                    throw new IllegalStateException("View not found for action " + getId());
+                }
+                ViewData viewData = ViewControllerUtils.getViewData(view);
+                instanceContainer = viewData.getContainer(dataContainer);
+            }
+        }
+
+        return instanceContainer;
+    }
+}

--- a/src/main/java/io/openbpm/control/configuration/CamundaFeignConfiguration.java
+++ b/src/main/java/io/openbpm/control/configuration/CamundaFeignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Haulmont 2024. All Rights Reserved.
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
  * Use is subject to license terms.
  */
 
@@ -15,14 +15,17 @@ import feign.codec.ErrorDecoder;
 import io.openbpm.control.restsupport.DynamicEngineUrlRequestInterceptor;
 import io.openbpm.control.restsupport.FeignClientProvider;
 import io.openbpm.control.restsupport.ObjectToStringConverter;
+import io.openbpm.control.restsupport.camunda.CamundaFeignErrorDecoder;
 import io.openbpm.control.service.engine.EngineService;
 import org.camunda.community.rest.EnableCamundaRestClient;
 import org.camunda.community.rest.client.FeignClientConfiguration;
+import org.camunda.community.rest.config.CamundaRestClientProperties;
 import org.springframework.cloud.openfeign.FeignClientProperties;
 import org.springframework.cloud.openfeign.FeignClientsConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 
 import java.util.Optional;
 
@@ -50,5 +53,12 @@ public class CamundaFeignConfiguration {
     @Bean("control_ObjectToStringConverter")
     public ObjectToStringConverter objectToStringConverter() {
         return new ObjectToStringConverter();
+    }
+
+
+    @Bean("control_CamundaFeignErrorDecoder")
+    @Primary
+    public ErrorDecoder errorDecoder(CamundaRestClientProperties restClientProperties) {
+        return new CamundaFeignErrorDecoder(restClientProperties);
     }
 }

--- a/src/main/java/io/openbpm/control/entity/deployment/ResourceDeploymentReport.java
+++ b/src/main/java/io/openbpm/control/entity/deployment/ResourceDeploymentReport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.entity.deployment;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+@JmixEntity
+public class ResourceDeploymentReport {
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    private String filename;
+
+    private List<ResourceValidationError> validationErrors;
+
+    public List<ResourceValidationError> getValidationErrors() {
+        return validationErrors;
+    }
+
+    public void setValidationErrors(List<ResourceValidationError> validationErrors) {
+        this.validationErrors = validationErrors;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+}

--- a/src/main/java/io/openbpm/control/entity/deployment/ResourceValidationError.java
+++ b/src/main/java/io/openbpm/control/entity/deployment/ResourceValidationError.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.entity.deployment;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import java.util.UUID;
+
+@JmixEntity
+public class ResourceValidationError {
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    private String message;
+
+    private Integer line;
+
+    private Integer column;
+
+    private String mainElementId;
+
+    private String type;
+
+    public ValidationErrorType getType() {
+        return type == null ? null : ValidationErrorType.fromId(type);
+    }
+
+    public void setType(ValidationErrorType type) {
+        this.type = type == null ? null : type.getId();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getMainElementId() {
+        return mainElementId;
+    }
+
+    public void setMainElementId(String mainElementId) {
+        this.mainElementId = mainElementId;
+    }
+
+    public Integer getColumn() {
+        return column;
+    }
+
+    public void setColumn(Integer column) {
+        this.column = column;
+    }
+
+    public Integer getLine() {
+        return line;
+    }
+
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/io/openbpm/control/entity/deployment/ValidationErrorType.java
+++ b/src/main/java/io/openbpm/control/entity/deployment/ValidationErrorType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.entity.deployment;
+
+import io.jmix.core.metamodel.datatype.EnumClass;
+
+import org.springframework.lang.Nullable;
+
+
+public enum ValidationErrorType implements EnumClass<String> {
+
+    ERROR("Error"),
+    WARNING("Warning");
+
+    private final String id;
+
+    ValidationErrorType(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Nullable
+    public static ValidationErrorType fromId(String id) {
+        for (ValidationErrorType at : ValidationErrorType.values()) {
+            if (at.getId().equals(id)) {
+                return at;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/openbpm/control/exception/RemoteEngineParseException.java
+++ b/src/main/java/io/openbpm/control/exception/RemoteEngineParseException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.exception;
+
+import io.openbpm.control.restsupport.camunda.ResourceReport;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Exception for the <code>ParseException</code> type returned in the {@link io.openbpm.control.restsupport.camunda.CamundaErrorResponse}.
+ * @see io.openbpm.control.restsupport.camunda.ParseExceptionResponse
+ */
+@Getter
+@Setter
+public class RemoteEngineParseException extends RemoteProcessEngineException {
+    protected Map<String, ResourceReport> details;
+
+    public RemoteEngineParseException(String message) {
+        super(message);
+        details = new HashMap<>();
+    }
+
+    public RemoteEngineParseException(String message, Map<String, ResourceReport> details) {
+        super(message);
+        this.details = details;
+    }
+}

--- a/src/main/java/io/openbpm/control/exception/RemoteProcessEngineException.java
+++ b/src/main/java/io/openbpm/control/exception/RemoteProcessEngineException.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.exception;
+
+import io.openbpm.control.restsupport.camunda.CamundaErrorResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.camunda.bpm.engine.ProcessEngineException;
+
+/**
+ * Generic class for exceptions thrown by remote BPM engine.
+ */
+public class RemoteProcessEngineException extends ProcessEngineException {
+    protected String responseMessage;
+    protected String engineExceptionType;
+
+    public RemoteProcessEngineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RemoteProcessEngineException(String message) {
+        super(message);
+    }
+
+    public String getEngineExceptionMessage() {
+        if (engineExceptionType == null) {
+            return responseMessage;
+        }
+        return engineExceptionType + ": " + responseMessage;
+    }
+
+    public static RemoteProcessEngineException defaultException(CamundaErrorResponse response) {
+        return new RemoteProcessEngineException("Error during remote BPM engine invocation with %s: %s".formatted(response.getType(), response.getMessage()))
+                .withResponseMessage(response.getMessage())
+                .withEngineExceptionType(response.getType());
+    }
+
+    public String getResponseMessage() {
+        return responseMessage;
+    }
+
+    public String getEngineExceptionType() {
+        return engineExceptionType;
+    }
+
+    public void setResponseMessage(String responseMessage) {
+        this.responseMessage = responseMessage;
+    }
+
+    public void setEngineExceptionType(String engineExceptionType) {
+        this.engineExceptionType = engineExceptionType;
+    }
+
+    public RemoteProcessEngineException withResponseMessage(String responseMessage) {
+        this.responseMessage = responseMessage;
+        return this;
+    }
+
+    public RemoteProcessEngineException withEngineExceptionType(String engineExceptionType) {
+        this.engineExceptionType = engineExceptionType;
+        return this;
+    }
+
+    public boolean isProcessEngineException() {
+        return StringUtils.equals("ProcessEngineException", engineExceptionType);
+    }
+}

--- a/src/main/java/io/openbpm/control/restsupport/camunda/CamundaErrorResponse.java
+++ b/src/main/java/io/openbpm/control/restsupport/camunda/CamundaErrorResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.restsupport.camunda;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Generic DTO for the error response returned by Camunda 7 REST.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CamundaErrorResponse {
+
+    @JsonProperty("type")
+    protected String type;
+
+    @JsonProperty("message")
+    protected String message;
+
+    @JsonProperty("code")
+    protected String code;
+
+}

--- a/src/main/java/io/openbpm/control/restsupport/camunda/CamundaFeignErrorDecoder.java
+++ b/src/main/java/io/openbpm/control/restsupport/camunda/CamundaFeignErrorDecoder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.restsupport.camunda;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import io.openbpm.control.exception.RemoteEngineParseException;
+import io.openbpm.control.exception.RemoteProcessEngineException;
+import org.apache.commons.io.IOUtils;
+import org.camunda.community.rest.config.CamundaRestClientProperties;
+import org.camunda.community.rest.config.ErrorDecoding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Handles response errors from the Camunda REST API.
+ */
+public class CamundaFeignErrorDecoder implements ErrorDecoder {
+    protected static final Logger log = LoggerFactory.getLogger(CamundaFeignErrorDecoder.class);
+
+    protected final CamundaRestClientProperties camundaRestClientProperties;
+    protected final ErrorDecoder defaultErrorDecoder;
+    protected final ObjectMapper objectMapper;
+
+    public CamundaFeignErrorDecoder(CamundaRestClientProperties camundaRestClientProperties) {
+        this.camundaRestClientProperties = camundaRestClientProperties;
+        this.objectMapper = new ObjectMapper();
+        this.defaultErrorDecoder = new Default();
+    }
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        ErrorDecoding errorDecoding = camundaRestClientProperties.getErrorDecoding();
+
+        List<Integer> httpCodes = errorDecoding.getHttpCodes();
+        if (httpCodes.contains(response.status())) {
+            Exception decodedException = decodeException(response);
+            if (decodedException != null) {
+                if (errorDecoding.getWrapExceptions() && !(decodedException instanceof RemoteProcessEngineException)) {
+                    return new RemoteProcessEngineException("Error during remote BPM engine engine invocation", decodedException);
+                } else {
+                    return decodedException;
+                }
+            } else {
+                return new RemoteProcessEngineException("Error during remote BPM engine invocation of %s: %s".formatted(methodKey, response.reason()));
+            }
+        }
+
+        return defaultErrorDecoder.decode(methodKey, response);
+    }
+
+    /**
+     * Creates an exception depending on the provided response.
+     *
+     * @param feignResponse response received from the Camunda
+     * @return exception instance
+     */
+    protected Exception decodeException(Response feignResponse) {
+        try {
+            String responseContent = IOUtils.toString(feignResponse.body().asInputStream(), StandardCharsets.UTF_8);
+            CamundaErrorResponse errorResponse = objectMapper.readValue(responseContent, CamundaErrorResponse.class);
+
+            String type = errorResponse.getType();
+
+            Exception exceptionFromResponse;
+            if (type.equals("ParseException")) {
+                exceptionFromResponse = createParseException(responseContent);
+            } else {
+                exceptionFromResponse = createExceptionByType(errorResponse);
+            }
+
+            return exceptionFromResponse != null ? exceptionFromResponse : RemoteProcessEngineException.defaultException(errorResponse);
+        } catch (IOException e) {
+            log.error("Unable to parse error response from BPM engine: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Creates an exception depending on the type from the provided response.
+     *
+     * @param errorResponse Camunda error response
+     * @return created exception or null if creation fails
+     */
+    protected Exception createExceptionByType(CamundaErrorResponse errorResponse) {
+        try {
+            Class<?> exceptionClass = Class.forName(errorResponse.getType());
+            if (Throwable.class.isAssignableFrom(exceptionClass)) {
+                Constructor<?> constructor = exceptionClass.getConstructor(String.class);
+
+                return (Exception) constructor.newInstance(errorResponse.getMessage());
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            log.debug("Unable to create exception by returned type {}: {}", errorResponse.getType(), e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Creates an instance of {@link RemoteEngineParseException} with the list of error from the provided response.
+     *
+     * @param responseContent Camunda response JSON
+     * @return {@link RemoteEngineParseException} instance or null if error occurred during JSON processing
+     */
+    @Nullable
+    protected Exception createParseException(String responseContent) {
+        try {
+            ParseExceptionResponse parseExceptionResponse = objectMapper.readValue(responseContent, ParseExceptionResponse.class);
+            return new RemoteEngineParseException(parseExceptionResponse.getMessage(), parseExceptionResponse.getDetails());
+        } catch (JsonProcessingException e) {
+            log.error("Unable to parse exception response from BPM engine: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/openbpm/control/restsupport/camunda/ParseExceptionResponse.java
+++ b/src/main/java/io/openbpm/control/restsupport/camunda/ParseExceptionResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.restsupport.camunda;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+/**
+ * A DTO for the error response with the  <code>ParseException</code> type.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ParseExceptionResponse extends CamundaErrorResponse {
+
+    private Map<String, ResourceReport> details;
+
+}

--- a/src/main/java/io/openbpm/control/restsupport/camunda/ResourceReport.java
+++ b/src/main/java/io/openbpm/control/restsupport/camunda/ResourceReport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.restsupport.camunda;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourceReport {
+    private List<ProblemDetails> errors;
+
+    private List<ProblemDetails> warnings;
+
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ProblemDetails {
+        private String message;
+
+        private Integer line;
+
+        private Integer column;
+
+        private String mainElementId;
+    }
+}

--- a/src/main/java/io/openbpm/control/view/AbstractResourceDeploymentView.java
+++ b/src/main/java/io/openbpm/control/view/AbstractResourceDeploymentView.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view;
+
+import io.jmix.core.DataManager;
+import io.jmix.core.Messages;
+import io.jmix.flowui.DialogWindows;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.openbpm.control.entity.deployment.ResourceDeploymentReport;
+import io.openbpm.control.entity.deployment.ResourceValidationError;
+import io.openbpm.control.entity.deployment.ValidationErrorType;
+import io.openbpm.control.restsupport.camunda.ResourceReport;
+import io.openbpm.control.view.deploymenterror.DeploymentErrorDialogView;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractResourceDeploymentView extends StandardView {
+    @ViewComponent
+    protected InstanceContainer<ResourceDeploymentReport> deploymentReportDc;
+
+    @Autowired
+    protected Messages messages;
+
+    @Autowired
+    protected DataManager dataManager;
+
+    @Autowired
+    protected DialogWindows dialogWindows;
+
+    @ViewComponent
+    protected JmixButton errorsBtn;
+
+
+    protected void initDeploymentErrorsButton() {
+        errorsBtn.addClickListener(event -> openValidationErrorDialogsView());
+    }
+
+    protected void handleResourceReport(ResourceReport resourceReport, String uploadedFileName) {
+        if (resourceReport != null) {
+            ResourceDeploymentReport deploymentReport = createResourceReport(resourceReport, uploadedFileName);
+
+            deploymentReportDc.setItem(deploymentReport);
+        }
+
+        openValidationErrorDialogsView();
+
+        updateErrorButtonText();
+    }
+
+    protected void updateErrorButtonText() {
+        ResourceDeploymentReport report = deploymentReportDc.getItem();
+        int size = CollectionUtils.size(report.getValidationErrors());
+        errorsBtn.setVisible(true);
+
+        String sizeText = size > 99 ? "99+" : String.valueOf(size);
+        String errorBtnText = messages.formatMessage(AbstractResourceDeploymentView.class, "deploymentErrorsBtn.text", sizeText);
+        errorsBtn.setText(errorBtnText);
+    }
+
+
+    protected ResourceDeploymentReport createResourceReport(ResourceReport report, String uploadedFileName) {
+        ResourceDeploymentReport deploymentReport = dataManager.create(ResourceDeploymentReport.class);
+        deploymentReport.setFilename(uploadedFileName);
+
+        List<ResourceValidationError> errors = new ArrayList<>();
+        addValidationErrors(report.getErrors(), ValidationErrorType.ERROR, errors);
+        addValidationErrors(report.getWarnings(), ValidationErrorType.WARNING, errors);
+
+        deploymentReport.setValidationErrors(errors);
+
+        return deploymentReport;
+    }
+
+    protected void openValidationErrorDialogsView() {
+        dialogWindows.view(this, DeploymentErrorDialogView.class)
+                .withViewConfigurer(deploymentErrorDialogView -> {
+                    deploymentErrorDialogView.setResourceReport(deploymentReportDc.getItem());
+                })
+                .open();
+    }
+
+    protected void addValidationErrors(List<ResourceReport.ProblemDetails> problemDetailsList, ValidationErrorType warning, List<ResourceValidationError> result) {
+        if (problemDetailsList != null) {
+            problemDetailsList.forEach(problemDetails -> {
+                ResourceValidationError resourceValidationError = createValidationError(warning, problemDetails);
+
+                result.add(resourceValidationError);
+            });
+        }
+    }
+
+    protected ResourceValidationError createValidationError(ValidationErrorType error, ResourceReport.ProblemDetails problemDetails) {
+        ResourceValidationError resourceValidationError = dataManager.create(ResourceValidationError.class);
+        resourceValidationError.setType(error);
+
+        resourceValidationError.setMessage(problemDetails.getMessage());
+        resourceValidationError.setColumn(problemDetails.getColumn());
+        resourceValidationError.setMainElementId(problemDetails.getMainElementId());
+        resourceValidationError.setLine(problemDetails.getLine());
+
+        return resourceValidationError;
+    }
+}

--- a/src/main/java/io/openbpm/control/view/deploymenterror/DeploymentErrorDialogView.java
+++ b/src/main/java/io/openbpm/control/view/deploymenterror/DeploymentErrorDialogView.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.deploymenterror;
+
+
+import io.jmix.core.LoadContext;
+import io.jmix.flowui.model.CollectionLoader;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.view.DialogMode;
+import io.jmix.flowui.view.Install;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.Target;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import io.jmix.gridexportflowui.action.ExcelExportAction;
+import io.jmix.gridexportflowui.exporter.ExportMode;
+import io.openbpm.control.entity.deployment.ResourceDeploymentReport;
+import io.openbpm.control.entity.deployment.ResourceValidationError;
+import org.apache.commons.io.FilenameUtils;
+
+import java.util.List;
+
+@ViewController(id = "DeploymentErrorDialogView")
+@ViewDescriptor(path = "deployment-error-dialog-view.xml")
+@DialogMode(width = "60em")
+public class DeploymentErrorDialogView extends StandardView {
+
+    @ViewComponent("resourceValidationErrorsDataGrid.excelExport")
+    protected ExcelExportAction resourceValidationErrorsDataGridExcelExport;
+
+    @ViewComponent
+    protected InstanceContainer<ResourceDeploymentReport> deploymentReportDc;
+
+    @ViewComponent
+    protected CollectionLoader<ResourceValidationError> validationErrorsDl;
+
+    public void setResourceReport(ResourceDeploymentReport report) {
+        deploymentReportDc.setItem(report);
+    }
+
+    @Subscribe
+    protected void onBeforeShow(final BeforeShowEvent event) {
+        validationErrorsDl.load();
+
+        resourceValidationErrorsDataGridExcelExport.setAvailableExportModes(List.of(ExportMode.ALL_ROWS));
+        ResourceDeploymentReport item = deploymentReportDc.getItem();
+        resourceValidationErrorsDataGridExcelExport.setFileName(FilenameUtils.getBaseName(item.getFilename()) + "-errors");
+    }
+
+    @Install(to = "validationErrorsDl", target = Target.DATA_LOADER)
+    protected List<ResourceValidationError> validationErrorsDlLoadDelegate(final LoadContext<ResourceValidationError> loadContext) {
+        //workaround for Excel export action because it does not work with container without loader
+        return deploymentReportDc.getItem().getValidationErrors();
+    }
+
+}

--- a/src/main/java/io/openbpm/control/view/deploymenterror/MainElementIdColumnFragment.java
+++ b/src/main/java/io/openbpm/control/view/deploymenterror/MainElementIdColumnFragment.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.deploymenterror;
+
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
+import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.view.ViewComponent;
+import io.openbpm.control.entity.deployment.ResourceValidationError;
+import org.apache.commons.lang3.StringUtils;
+
+@RendererItemContainer("validationErrorDc")
+@FragmentDescriptor("main-element-id-column-fragment.xml")
+public class MainElementIdColumnFragment extends FragmentRenderer<HorizontalLayout, ResourceValidationError> {
+
+    @ViewComponent
+    protected JmixButton copyValueBtn;
+
+    @Override
+    public void setItem(ResourceValidationError item) {
+        super.setItem(item);
+
+        copyValueBtn.setVisible(StringUtils.isNotBlank(item.getMainElementId()));
+    }
+}

--- a/src/main/java/io/openbpm/control/view/deploymenterror/ValidationErrorMessageColumnFragment.java
+++ b/src/main/java/io/openbpm/control/view/deploymenterror/ValidationErrorMessageColumnFragment.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.deploymenterror;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.popover.Popover;
+import com.vaadin.flow.component.popover.PopoverPosition;
+import io.jmix.flowui.Fragments;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
+import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
+import io.jmix.flowui.view.ViewComponent;
+import io.openbpm.control.entity.deployment.ResourceValidationError;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RendererItemContainer("validationErrorDc")
+@FragmentDescriptor("validation-error-message-column-fragment.xml")
+public class ValidationErrorMessageColumnFragment extends FragmentRenderer<HorizontalLayout, ResourceValidationError> {
+    @Autowired
+    protected Fragments fragments;
+
+    @ViewComponent
+    protected Span errorMessageText;
+
+    @Override
+    public void setItem(ResourceValidationError item) {
+        super.setItem(item);
+
+        String message = item.getMessage();
+        if (StringUtils.isNotEmpty(message)) {
+            ValidationMessageTooltipFragment tooltipFragment = fragments.create(this, ValidationMessageTooltipFragment.class);
+            tooltipFragment.setText(message);
+
+            Popover popover = new Popover(tooltipFragment);
+            popover.setPosition(PopoverPosition.BOTTOM_START);
+            popover.setTarget(errorMessageText);
+        }
+    }
+
+}

--- a/src/main/java/io/openbpm/control/view/deploymenterror/ValidationErrorTypeColumnFragment.java
+++ b/src/main/java/io/openbpm/control/view/deploymenterror/ValidationErrorTypeColumnFragment.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.deploymenterror;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
+import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
+import io.jmix.flowui.view.ViewComponent;
+import io.openbpm.control.entity.deployment.ResourceValidationError;
+import io.openbpm.control.entity.deployment.ValidationErrorType;
+
+@RendererItemContainer("validationErrorDc")
+@FragmentDescriptor("validation-error-type-column-fragment.xml")
+public class ValidationErrorTypeColumnFragment extends FragmentRenderer<HorizontalLayout, ResourceValidationError> {
+
+    @ViewComponent
+    protected Span errorType;
+
+    @Override
+    public void setItem(ResourceValidationError item) {
+        super.setItem(item);
+
+        ValidationErrorType type = item.getType();
+        switch (type) {
+            case ERROR -> errorType.getElement().getThemeList().add("error");
+            case WARNING -> errorType.getElement().getThemeList().add("warning");
+            case null -> errorType.setVisible(false);
+            default -> errorType.getElement().getThemeList().add("contrast");
+        }
+    }
+}

--- a/src/main/java/io/openbpm/control/view/deploymenterror/ValidationMessageTooltipFragment.java
+++ b/src/main/java/io/openbpm/control/view/deploymenterror/ValidationMessageTooltipFragment.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.deploymenterror;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.popover.Popover;
+import io.jmix.flowui.fragment.Fragment;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.ViewComponent;
+
+import java.util.Optional;
+
+@FragmentDescriptor("validation-message-tooltip-fragment.xml")
+public class ValidationMessageTooltipFragment extends Fragment<HorizontalLayout> {
+
+    @ViewComponent
+    private Span errorMessage;
+
+    public void setText(String text) {
+        errorMessage.setText(text);
+    }
+
+    @Subscribe(id = "closeBtn", subject = "clickListener")
+    protected void onCloseBtnClick(final ClickEvent<JmixButton> event) {
+        Popover popover = findPopover(this);
+        if (popover != null) {
+            popover.close();
+        }
+    }
+
+    protected Popover findPopover(Component component) {
+        if (component instanceof Popover) {
+            return (Popover) component;
+        } else {
+            Optional<Component> parent = component.getParent();
+            return parent.map(this::findPopover).orElse(null);
+        }
+    }
+}

--- a/src/main/resources/io/openbpm/control/messages_de.properties
+++ b/src/main/resources/io/openbpm/control/messages_de.properties
@@ -16,6 +16,7 @@ actions.View=Anzeigen
 actions.Terminate=Beenden
 actions.TestConnection=Verbindung testen
 actions.Copy=Kopieren
+actions.Download=Herunterladen
 
 viewer.openDecisionInstanceOverlay.tooltipMessage=Entscheidungsinstanz mit ID öffnen: %s
 
@@ -275,6 +276,11 @@ io.openbpm.control.view.decisioninstance.filter/processDefinitionKey.placeHolder
 io.openbpm.control.view.decisioninstance.filter/activityId.placeHolder=Aktivitäts-ID eingeben
 io.openbpm.control.view.decisioninstance.filter/processInstanceId.placeHolder=Prozessinstanz-ID eingeben
 
+io.openbpm.control.view.deploymenterror/deploymentErrorDialogView.title=Bereitstellungsfehler
+io.openbpm.control.view.deploymenterror/errorsAndWarningsHeader.text=Fehler und Warnungen
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.description.text=Beheben Sie die Probleme in der hochgeladenen Datei und versuchen Sie erneut, sie bereitzustellen
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.text=Ressource nicht bereitgestellt
+
 io.openbpm.control.view.engineconnectionsettings/authType=Typ
 io.openbpm.control.view.engineconnectionsettings/authentication=Authentifizierung
 io.openbpm.control.view.engineconnectionsettings/baseUrl=Basis-URL
@@ -382,6 +388,7 @@ io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.heade
 io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.text=Sind Sie sicher, dass Sie die folgenden Prozesse bereitstellen möchten?
 io.openbpm.control.view.newprocessdeployment/deploy=Bereitstellen
 io.openbpm.control.view.newprocessdeployment/errorOnUploadedFileReading=Ausgewählte Datei konnte nicht gelesen werden
+io.openbpm.control.view.newprocessdeployment/errorsBtn.text=Fehler (%s)
 io.openbpm.control.view.newprocessdeployment/existingProcessesFound=Vorhandene Prozesse gefunden
 io.openbpm.control.view.newprocessdeployment/importedProcessKeyAndName=Prozess #%s: %s (%s)
 io.openbpm.control.view.newprocessdeployment/noImportedProcesses=Keine Prozesse
@@ -617,6 +624,8 @@ io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ACTIVE=Aktiv
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ALL=Alle
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.COMPLETED=Abgeschlossen
 
+io.openbpm.control.view/deploymentErrorsBtn.text=Fehler (%s)
+
 io.openbpm.control/allTasks=Benutzeraufgaben
 
 io.openbpm.control.entity.activity/ActivityInstanceTreeItem=Aktivitätsinstanz-Baumobjekt
@@ -671,6 +680,13 @@ io.openbpm.control.entity.deployment/DeploymentResource.deploymentId=Deployment-
 io.openbpm.control.entity.deployment/DeploymentResource.id=ID
 io.openbpm.control.entity.deployment/DeploymentResource.name=Name
 io.openbpm.control.entity.deployment/DeploymentResource.resourceId=Ressourcen-ID
+io.openbpm.control.entity.deployment/ResourceDeploymentReport=Bericht zur Ressourcenbereitstellung
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.filename=Dateiname
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.id=ID
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.validationErrors=Validierungsfehler
+io.openbpm.control.entity.deployment/ValidationErrorType=Validierungsfehlertyp
+io.openbpm.control.entity.deployment/ValidationErrorType.ERROR=Fehler
+io.openbpm.control.entity.deployment/ValidationErrorType.WARNING=Warnung
 
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.category=Kategorie
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.decisionDefinitionId=Entscheidungsdefinitions-ID

--- a/src/main/resources/io/openbpm/control/messages_en.properties
+++ b/src/main/resources/io/openbpm/control/messages_en.properties
@@ -16,6 +16,7 @@ actions.View=View
 actions.Terminate=Terminate
 actions.TestConnection=Test connection
 actions.Copy=Copy
+actions.Download=Download
 
 viewer.openDecisionInstanceOverlay.tooltipMessage=Open decision instance with id: %s
 
@@ -278,6 +279,11 @@ io.openbpm.control.view.decisioninstance.filter/processDefinitionKey.placeHolder
 io.openbpm.control.view.decisioninstance.filter/activityId.placeHolder=Enter an activity id
 io.openbpm.control.view.decisioninstance.filter/processInstanceId.placeHolder=Enter a process instance id
 
+io.openbpm.control.view.deploymenterror/deploymentErrorDialogView.title=Deployment errors
+io.openbpm.control.view.deploymenterror/errorsAndWarningsHeader.text=Errors & warnings
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.description.text=Resolve the problems in the uploaded file and try to deploy it again
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.text=Resource not deployed
+
 io.openbpm.control.view.engineconnectionsettings/authType=Type
 io.openbpm.control.view.engineconnectionsettings/authentication=Authentication
 io.openbpm.control.view.engineconnectionsettings/baseUrl=Base URL
@@ -387,6 +393,7 @@ io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.heade
 io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.text=Are you sure you want to deploy the following processes?
 io.openbpm.control.view.newprocessdeployment/deploy=Deploy
 io.openbpm.control.view.newprocessdeployment/errorOnUploadedFileReading=Unable to read selected file
+io.openbpm.control.view.newprocessdeployment/errorsBtn.text=Errors (%s)
 io.openbpm.control.view.newprocessdeployment/existingProcessesFound=Existing processes found
 io.openbpm.control.view.newprocessdeployment/importedProcessKeyAndName=Process #%s: %s (%s)
 io.openbpm.control.view.newprocessdeployment/noImportedProcesses=No processes
@@ -602,6 +609,7 @@ io.openbpm.control.view.processvariable/variableInstanceData.detail.title=Variab
 io.openbpm.control.view.processvariable/variableInstanceDataEdit.value=Value
 io.openbpm.control.view.processvariable/variableValueUpdated=Variable value updated
 
+
 io.openbpm.control.view.startprocess/processDefinitionIdLabel=Id
 io.openbpm.control.view.startprocess/startProcess=Start
 io.openbpm.control.view.startprocess/startProcessView.processDefinitionNotFound=Process definition not found
@@ -625,6 +633,8 @@ io.openbpm.control.view.processinstance/ProcessInstanceViewMode=Process instance
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ACTIVE=Active
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ALL=All
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.COMPLETED=Completed
+
+io.openbpm.control.view/deploymentErrorsBtn.text=Errors (%s)
 
 io.openbpm.control/allTasks=User tasks
 
@@ -680,6 +690,23 @@ io.openbpm.control.entity.deployment/DeploymentResource.deploymentId=Deployment 
 io.openbpm.control.entity.deployment/DeploymentResource.id=Id
 io.openbpm.control.entity.deployment/DeploymentResource.name=Name
 io.openbpm.control.entity.deployment/DeploymentResource.resourceId=Resource id
+io.openbpm.control.entity.deployment/ResourceDeploymentReport=Resource deployment report
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.filename=Filename
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.id=Id
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.validationErrors=Validation errors
+io.openbpm.control.entity.deployment/ResourceReport=Resource report
+io.openbpm.control.entity.deployment/ResourceReport.id=Id
+io.openbpm.control.entity.deployment/ResourceReport.validationError=Validation error
+io.openbpm.control.entity.deployment/ResourceValidationError=Resource validation error
+io.openbpm.control.entity.deployment/ResourceValidationError.column=Column
+io.openbpm.control.entity.deployment/ResourceValidationError.id=Id
+io.openbpm.control.entity.deployment/ResourceValidationError.line=Line
+io.openbpm.control.entity.deployment/ResourceValidationError.mainElementId=Main element id
+io.openbpm.control.entity.deployment/ResourceValidationError.message=Message
+io.openbpm.control.entity.deployment/ResourceValidationError.type=Type
+io.openbpm.control.entity.deployment/ValidationErrorType=Validation error type
+io.openbpm.control.entity.deployment/ValidationErrorType.ERROR=Error
+io.openbpm.control.entity.deployment/ValidationErrorType.WARNING=Warning
 
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.category=Category
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.decisionDefinitionId=Decision definition id

--- a/src/main/resources/io/openbpm/control/messages_es.properties
+++ b/src/main/resources/io/openbpm/control/messages_es.properties
@@ -16,6 +16,7 @@ actions.View=Ver
 actions.Terminate=Terminar
 actions.TestConnection=Probar conexión
 actions.Copy=Copiar
+actions.Download=Download
 
 viewer.openDecisionInstanceOverlay.tooltipMessage=Abrir instancia de decisión con id: %s
 
@@ -206,6 +207,12 @@ io.openbpm.control.view.engineconnectionsettings/customHeaderName=Nombre del enc
 io.openbpm.control.view.engineconnectionsettings/customHeaderValue=Valor del encabezado
 io.openbpm.control.view.engineconnectionsettings/basicAuthPasswordCopied=¡Contraseña copiada!
 io.openbpm.control.view.engineconnectionsettings/basicAuthPasswordCopyFailed=¡No se pudo copiar la contraseña!
+
+io.openbpm.control.view.deploymenterror/deploymentErrorDialogView.title=Errores de implementación
+io.openbpm.control.view.deploymenterror/errorsAndWarningsHeader.text=Errores y advertencias
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.description.text=Resuelva los problemas en el archivo cargado e intente implementarlo nuevamente
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.text=Recurso no implementado
+
 io.openbpm.control.view.engineconnectionsettings/authType=Tipo
 io.openbpm.control.view.engineconnectionsettings/authentication=Autenticación
 io.openbpm.control.view.engineconnectionsettings/baseUrl=URL base
@@ -381,6 +388,7 @@ io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.heade
 io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.text=¿Está seguro de que desea desplegar los siguientes procesos?
 io.openbpm.control.view.newprocessdeployment/deploy=Desplegar
 io.openbpm.control.view.newprocessdeployment/errorOnUploadedFileReading=No se pudo leer el archivo seleccionado
+io.openbpm.control.view.newprocessdeployment/errorsBtn.text=Errores (%s)
 io.openbpm.control.view.newprocessdeployment/existingProcessesFound=Procesos existentes encontrados
 io.openbpm.control.view.newprocessdeployment/importedProcessKeyAndName=Proceso #%s: %s (%s)
 io.openbpm.control.view.newprocessdeployment/noImportedProcesses=Sin procesos
@@ -616,6 +624,8 @@ io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ACTIVE=Activo
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ALL=Todos
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.COMPLETED=Completado
 
+io.openbpm.control.view/deploymentErrorsBtn.text=Errores (%s)
+
 io.openbpm.control/allTasks=Tareas de usuario
 
 io.openbpm.control.entity.activity/ActivityInstanceTreeItem=Elemento del árbol de instancias de actividad
@@ -670,6 +680,13 @@ io.openbpm.control.entity.deployment/DeploymentResource.deploymentId=Id de despl
 io.openbpm.control.entity.deployment/DeploymentResource.id=Id
 io.openbpm.control.entity.deployment/DeploymentResource.name=Nombre
 io.openbpm.control.entity.deployment/DeploymentResource.resourceId=Id de recurso
+io.openbpm.control.entity.deployment/ResourceDeploymentReport=Informe de implementación de recursos
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.filename=Nombre del archivo
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.id=Id
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.validationErrors=Errores de validación
+io.openbpm.control.entity.deployment/ValidationErrorType=Tipo de error de validación
+io.openbpm.control.entity.deployment/ValidationErrorType.ERROR=Error
+io.openbpm.control.entity.deployment/ValidationErrorType.WARNING=Advertencia
 
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.category=Categoría
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.decisionDefinitionId=Id de definición de decisión

--- a/src/main/resources/io/openbpm/control/messages_ru.properties
+++ b/src/main/resources/io/openbpm/control/messages_ru.properties
@@ -16,6 +16,7 @@ actions.View=Посмотреть
 actions.Terminate=Завершить
 actions.TestConnection=Проверить соединение
 actions.Copy=Скопировать
+actions.Download=Скачать
 
 viewer.openDecisionInstanceOverlay.tooltipMessage=Открыть экземпляр таблицы решений с id: %s
 
@@ -275,6 +276,11 @@ io.openbpm.control.view.decisioninstance.filter/processDefinitionKey.placeHolder
 io.openbpm.control.view.decisioninstance.filter/activityId.placeHolder=Введите id активности
 io.openbpm.control.view.decisioninstance.filter/processInstanceId.placeHolder=Введите id экземпляра процесса
 
+io.openbpm.control.view.deploymenterror/deploymentErrorDialogView.title=Ошибки развертывания ресурса
+io.openbpm.control.view.deploymenterror/errorsAndWarningsHeader.text=Ошибки и предупреждения
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.description.text=Устраните проблемы в загруженном файле и попробуйте развернуть его снова
+io.openbpm.control.view.deploymenterror/resourceNotDeployed.text=Ресурс не развернут
+
 io.openbpm.control.view.engineconnectionsettings/authType=Тип
 io.openbpm.control.view.engineconnectionsettings/authentication=Аутентификация
 io.openbpm.control.view.engineconnectionsettings/baseUrl=Базовый URL
@@ -384,6 +390,7 @@ io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.heade
 io.openbpm.control.view.newprocessdeployment/createDeploymentConfirmDialog.text=Вы уверены, что хотите развернуть следующие процессы?
 io.openbpm.control.view.newprocessdeployment/deploy=Развернуть
 io.openbpm.control.view.newprocessdeployment/errorOnUploadedFileReading=Не удалось прочитать выбранный файл
+io.openbpm.control.view.newprocessdeployment/errorsBtn.text=Ошибки (%s)
 io.openbpm.control.view.newprocessdeployment/existingProcessesFound=Найдены существующие процессы
 io.openbpm.control.view.newprocessdeployment/importedProcessKeyAndName=Процесс #%s: %s (%s)
 io.openbpm.control.view.newprocessdeployment/noImportedProcesses=Нет процессов
@@ -600,6 +607,7 @@ io.openbpm.control.view.processvariable/variableInstanceData.detail.title=Экз
 io.openbpm.control.view.processvariable/variableInstanceDataEdit.value=Значение
 io.openbpm.control.view.processvariable/variableValueUpdated=Значение переменной обновлено
 
+
 io.openbpm.control.view.startprocess/processDefinitionIdLabel=Id
 io.openbpm.control.view.startprocess/startProcess=Запустить
 io.openbpm.control.view.startprocess/startProcessView.processDefinitionNotFound=Процесс не найден
@@ -623,6 +631,8 @@ io.openbpm.control.view.processinstance/ProcessInstanceViewMode=Режим пр�
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ACTIVE=Активные
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.ALL=Все
 io.openbpm.control.view.processinstance/ProcessInstanceViewMode.COMPLETED=Завершенные
+
+io.openbpm.control.view/deploymentErrorsBtn.text=Ошибки (%s)
 
 io.openbpm.control/allTasks=Пользовательские задачи
 
@@ -678,6 +688,23 @@ io.openbpm.control.entity.deployment/DeploymentResource.deploymentId=Id разв
 io.openbpm.control.entity.deployment/DeploymentResource.id=Id
 io.openbpm.control.entity.deployment/DeploymentResource.name=Название
 io.openbpm.control.entity.deployment/DeploymentResource.resourceId=Id ресурса
+io.openbpm.control.entity.deployment/ResourceDeploymentReport=Resource deployment report
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.filename=Filename
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.id=Id
+io.openbpm.control.entity.deployment/ResourceDeploymentReport.validationErrors=Validation errors
+io.openbpm.control.entity.deployment/ResourceReport=Resource report
+io.openbpm.control.entity.deployment/ResourceReport.id=Id
+io.openbpm.control.entity.deployment/ResourceReport.validationError=Validation error
+io.openbpm.control.entity.deployment/ResourceValidationError=Resource validation error
+io.openbpm.control.entity.deployment/ResourceValidationError.column=Столбец
+io.openbpm.control.entity.deployment/ResourceValidationError.id=Id
+io.openbpm.control.entity.deployment/ResourceValidationError.line=Строка
+io.openbpm.control.entity.deployment/ResourceValidationError.mainElementId=Id основного элемента
+io.openbpm.control.entity.deployment/ResourceValidationError.message=Сообщение
+io.openbpm.control.entity.deployment/ResourceValidationError.type=Тип
+io.openbpm.control.entity.deployment/ValidationErrorType=Тип ошибки валидации
+io.openbpm.control.entity.deployment/ValidationErrorType.ERROR=Ошибка
+io.openbpm.control.entity.deployment/ValidationErrorType.WARNING=Предупреждение
 
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.category=Категория
 io.openbpm.control.entity.decisiondefinition/DecisionDefinitionData.decisionDefinitionId=Id определения решения

--- a/src/main/resources/io/openbpm/control/view/decisiondeployment/decision-deployment-view.xml
+++ b/src/main/resources/io/openbpm/control/view/decisiondeployment/decision-deployment-view.xml
@@ -6,6 +6,9 @@
 
 <view xmlns="http://jmix.io/schema/flowui/view"
       title="msg://decisionDeploymentView.title">
+    <data>
+        <instance id="deploymentReportDc" class="io.openbpm.control.entity.deployment.ResourceDeploymentReport"/>
+    </data>
     <layout expand="uploadVBox">
         <vbox id="uploadVBox" width="100%" expand="previewVBox" padding="false">
             <hbox alignItems="BASELINE" width="100%" expand="decisionInfoHBox">
@@ -18,6 +21,14 @@
                                  uploadText="msg://io.openbpm.control.view.decisiondeployment/uploadDmnXml"
                                  acceptedFileTypes=".dmn,.dmn11.xml"
                                  uploadIcon="UPLOAD"/>
+
+                <button id="errorsBtn" visible="false"
+                        themeNames="badge error pill tertiary-inline has-icon">
+                    <prefix>
+                        <icon id="deploymentErrorsIcon" icon="WARNING"/>
+                    </prefix>
+                </button>
+
                 <hbox id="decisionInfoHBox" alignItems="BASELINE" visible="false" themeNames="spacing-s" padding="false"
                       justifyContent="END">
                     <icon id="decisionCountInfoIcon" icon="INFO_CIRCLE" size="1em" alignSelf="CENTER">

--- a/src/main/resources/io/openbpm/control/view/deploymenterror/deployment-error-dialog-view.xml
+++ b/src/main/resources/io/openbpm/control/view/deploymenterror/deployment-error-dialog-view.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view"
+      title="msg://deploymentErrorDialogView.title">
+    <data>
+        <instance id="deploymentReportDc"
+                  class="io.openbpm.control.entity.deployment.ResourceDeploymentReport"/>
+        <collection id="validationErrorsDc" class="io.openbpm.control.entity.deployment.ResourceValidationError">
+            <loader id="validationErrorsDl"/>
+        </collection>
+    </data>
+    <actions>
+        <action id="close" type="view_close" text="msg:///actions.Close"/>
+    </actions>
+    <layout>
+        <hbox width="100%" alignItems="AUTO" justifyContent="START" themeNames="spacing-s"
+              classNames="border rounded-l border-error-50 bg-error-10 text-error-contrast p-m">
+            <icon id="warningIcon" icon="WARNING" size="1.25em" classNames="text-error"/>
+            <vbox padding="false" themeNames="spacing-xs">
+                <h5 id="warningHeader" text="msg://resourceNotDeployed.text"/>
+                <span id="warningMessage" classNames="text-secondary"
+                      text="msg://resourceNotDeployed.description.text"/>
+            </vbox>
+        </hbox>
+        <h4 text="msg://errorsAndWarningsHeader.text"/>
+        <dataGrid id="resourceValidationErrorsDataGrid" dataContainer="validationErrorsDc" minWidth="100px"
+                  width="100%">
+            <actions showInContextMenuEnabled="false">
+                <action id="excelExport" type="grdexp_excelExport" text="msg:///actions.Download" icon="DOWNLOAD"/>
+            </actions>
+            <columns resizable="true">
+                <column property="message" flexGrow="2">
+                    <fragmentRenderer
+                            class="io.openbpm.control.view.deploymenterror.ValidationErrorMessageColumnFragment"/>
+                </column>
+                <column property="line" autoWidth="true" flexGrow="0"/>
+                <column property="column" autoWidth="true" flexGrow="0"/>
+                <column property="mainElementId" autoWidth="true" flexGrow="1">
+                    <fragmentRenderer
+                            class="io.openbpm.control.view.deploymenterror.MainElementIdColumnFragment"/>
+                </column>
+                <column property="type" autoWidth="true" flexGrow="0">
+                    <fragmentRenderer
+                            class="io.openbpm.control.view.deploymenterror.ValidationErrorTypeColumnFragment"/>
+                </column>
+            </columns>
+        </dataGrid>
+        <hbox padding="false" width="100%" justifyContent="END">
+            <button action="resourceValidationErrorsDataGrid.excelExport"/>
+            <button action="close"/>
+        </hbox>
+    </layout>
+</view>

--- a/src/main/resources/io/openbpm/control/view/deploymenterror/main-element-id-column-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/deploymenterror/main-element-id-column-fragment.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="validationErrorDc" class="io.openbpm.control.entity.deployment.ResourceValidationError"/>
+    </data>
+    <actions>
+        <action id="copy" type="control_copyEntityPropertyToClipboard" icon="COPY_O">
+            <properties>
+                <property name="text" value=""/>
+                <property name="dataContainer" value="validationErrorDc"/>
+                <property name="property" value="mainElementId"/>
+            </properties>
+        </action>
+    </actions>
+    <content>
+        <hbox id="root" padding="false" themeNames="spacing-s">
+            <span id="mainElementIdText" dataContainer="validationErrorDc" property="mainElementId"/>
+            <button id="copyValueBtn" themeNames="tertiary-inline small icon" classNames="text-secondary" action="copy"/>
+        </hbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/openbpm/control/view/deploymenterror/validation-error-message-column-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/deploymenterror/validation-error-message-column-fragment.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="validationErrorDc" class="io.openbpm.control.entity.deployment.ResourceValidationError"/>
+    </data>
+    <actions>
+        <action id="copy" type="control_copyEntityPropertyToClipboard" icon="COPY_O">
+            <properties>
+                <property name="text" value=""/>
+                <property name="dataContainer" value="validationErrorDc"/>
+                <property name="property" value="message"/>
+            </properties>
+        </action>
+    </actions>
+    <content>
+        <hbox id="root" padding="false" themeNames="spacing-s" >
+            <span id="errorMessageText" dataContainer="validationErrorDc" property="message"
+                  classNames="overflow-hidden overflow-ellipsis block border-b border-primary text-primary border-dashed"/>
+            <button id="copyValueBtn" themeNames="tertiary-inline small icon" classNames="text-secondary" action="copy"/>
+        </hbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/openbpm/control/view/deploymenterror/validation-error-type-column-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/deploymenterror/validation-error-type-column-fragment.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="validationErrorDc" class="io.openbpm.control.entity.deployment.ResourceValidationError"/>
+    </data>
+    <content>
+        <hbox id="root" padding="false">
+            <span id="errorType" themeNames="badge pill"
+                  dataContainer="validationErrorDc" property="type"/>
+        </hbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/openbpm/control/view/deploymenterror/validation-message-tooltip-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/deploymenterror/validation-message-tooltip-fragment.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <content>
+        <hbox id="root" themeNames="spacing-s" alignItems="START">
+            <span id="errorMessage" classNames="whitespace-pre-wrap block" width="40em"/>
+            <button id="closeBtn" icon="CLOSE_SMALL" themeNames="contrast tertiary-inline small icon"/>
+        </hbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/openbpm/control/view/newprocessdeployment/new-process-deployment-view.xml
+++ b/src/main/resources/io/openbpm/control/view/newprocessdeployment/new-process-deployment-view.xml
@@ -6,6 +6,9 @@
 
 <view xmlns="http://jmix.io/schema/flowui/view"
       title="msg://newProcessDeploymentView.title">
+    <data>
+        <instance id="deploymentReportDc" class="io.openbpm.control.entity.deployment.ResourceDeploymentReport"/>
+    </data>
     <layout expand="uploadVBox">
         <vbox id="uploadVBox" width="100%" expand="previewVBox" padding="false">
             <hbox alignItems="BASELINE" width="100%" expand="processInfoHBox">
@@ -18,6 +21,14 @@
                                  uploadText="msg://uploadBpmnXml"
                                  acceptedFileTypes=".bpmn,.bpmn20.xml"
                                  uploadIcon="UPLOAD"/>
+
+                <button id="errorsBtn" visible="false"
+                        themeNames="badge error pill tertiary-inline has-icon">
+                    <prefix>
+                        <icon id="deploymentErrorsIcon" icon="WARNING"/>
+                    </prefix>
+                </button>
+
                 <hbox id="processInfoHBox" alignItems="BASELINE" visible="false" themeNames="spacing-s" padding="false" justifyContent="END">
                     <icon id="processCountInfoIcon" icon="INFO_CIRCLE" size="1em" alignSelf="CENTER">
                         <tooltip text="msg://noImportedProcesses" position="BOTTOM_END" hideDelay="0" manual="false"

--- a/src/test/java/io/openbpm/control/service/deployment/Camunda7DeploymentServiceTest.java
+++ b/src/test/java/io/openbpm/control/service/deployment/Camunda7DeploymentServiceTest.java
@@ -7,6 +7,7 @@ package io.openbpm.control.service.deployment;
 
 import io.jmix.core.Resources;
 import io.openbpm.control.entity.deployment.DeploymentData;
+import io.openbpm.control.exception.RemoteEngineParseException;
 import io.openbpm.control.test_support.AuthenticatedAsAdmin;
 import io.openbpm.control.test_support.RunningEngine;
 import io.openbpm.control.test_support.WithRunningEngine;
@@ -17,7 +18,6 @@ import io.openbpm.control.test_support.camunda7.dto.response.DeploymentDto;
 import io.openbpm.control.test_support.camunda7.dto.response.DeploymentResultDto;
 import io.openbpm.control.test_support.camunda7.dto.response.ProcessDefinitionDto;
 import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
-import org.camunda.community.rest.exception.RemoteProcessEngineException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,7 +85,7 @@ public class Camunda7DeploymentServiceTest extends AbstractCamunda7IntegrationTe
     }
 
     @Test
-    @DisplayName("RemoteProcessEngineException occurs if deploy invalid BPMN 2.0 XML")
+    @DisplayName("RemoteEngineParseException occurs if deploy invalid BPMN 2.0 XML")
     void givenResourceNameAndInvalidBpmnXml_whenDeployWithContext_thenExceptionThrown() {
         //given
         String resourceName = "testDeployInvalidBpmnXml.bpmn";
@@ -94,7 +94,17 @@ public class Camunda7DeploymentServiceTest extends AbstractCamunda7IntegrationTe
 
         //when and then
         assertThatThrownBy(() -> deploymentService.createDeployment(deploymentContext))
-                .isInstanceOf(RemoteProcessEngineException.class);
+                .isInstanceOf(RemoteEngineParseException.class)
+                .satisfies(exception -> {
+                    RemoteEngineParseException parseException = (RemoteEngineParseException) exception;
+                    assertThat(parseException.getDetails())
+                            .hasSize(1)
+                            .containsKey(resourceName)
+                            .extractingByKey(resourceName)
+                            .satisfies(resourceReport -> {
+                                assertThat(resourceReport.getErrors()).hasSize(1);
+                            });
+                });
 
     }
 

--- a/src/test/java/io/openbpm/control/service/processdefinition/Camunda7ProcessDefinitionDeleteTest.java
+++ b/src/test/java/io/openbpm/control/service/processdefinition/Camunda7ProcessDefinitionDeleteTest.java
@@ -5,6 +5,7 @@
 
 package io.openbpm.control.service.processdefinition;
 
+import io.openbpm.control.exception.RemoteProcessEngineException;
 import io.openbpm.control.test_support.AuthenticatedAsAdmin;
 import io.openbpm.control.test_support.RunningEngine;
 import io.openbpm.control.test_support.WithRunningEngine;
@@ -14,7 +15,6 @@ import io.openbpm.control.test_support.camunda7.CamundaRestTestHelper;
 import io.openbpm.control.test_support.camunda7.CamundaSampleDataManager;
 import io.openbpm.control.test_support.camunda7.dto.response.HistoricProcessInstanceDto;
 import org.camunda.community.rest.client.model.ProcessInstanceDto;
-import org.camunda.community.rest.exception.RemoteProcessEngineException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/io/openbpm/control/service/processinstance/Camunda7ProcessInstanceStartTest.java
+++ b/src/test/java/io/openbpm/control/service/processinstance/Camunda7ProcessInstanceStartTest.java
@@ -8,6 +8,7 @@ package io.openbpm.control.service.processinstance;
 import io.jmix.core.DataManager;
 import io.openbpm.control.entity.processinstance.ProcessInstanceData;
 import io.openbpm.control.entity.variable.VariableInstanceData;
+import io.openbpm.control.exception.RemoteProcessEngineException;
 import io.openbpm.control.test_support.AuthenticatedAsAdmin;
 import io.openbpm.control.test_support.RunningEngine;
 import io.openbpm.control.test_support.WithRunningEngine;
@@ -18,7 +19,6 @@ import io.openbpm.control.test_support.camunda7.dto.response.DeploymentResultDto
 import io.openbpm.control.test_support.camunda7.dto.response.ProcessVariablesMapDto;
 import io.openbpm.control.test_support.camunda7.dto.response.RuntimeProcessInstanceDto;
 import io.openbpm.control.test_support.camunda7.dto.response.VariableInstanceDto;
-import org.camunda.community.rest.exception.RemoteProcessEngineException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,7 +96,7 @@ public class Camunda7ProcessInstanceStartTest extends AbstractCamunda7Integratio
     }
 
     @Test
-    @DisplayName("RemoteEngineException thrown if start process by non-existing process id")
+    @DisplayName("RemoteProcessEngineException thrown if start process by non-existing process id")
     void givenNonExistingProcessId_whenStartByProcessId_thenRemoteEngineExceptionThrown() {
         //given
         String processId = UUID.randomUUID().toString();

--- a/src/test/java/io/openbpm/control/service/usertask/Camunda7UserTaskCompleteTest.java
+++ b/src/test/java/io/openbpm/control/service/usertask/Camunda7UserTaskCompleteTest.java
@@ -7,6 +7,7 @@ package io.openbpm.control.service.usertask;
 
 import io.jmix.core.DataManager;
 import io.openbpm.control.entity.variable.VariableInstanceData;
+import io.openbpm.control.exception.RemoteProcessEngineException;
 import io.openbpm.control.test_support.AuthenticatedAsAdmin;
 import io.openbpm.control.test_support.RunningEngine;
 import io.openbpm.control.test_support.WithRunningEngine;
@@ -18,7 +19,6 @@ import io.openbpm.control.test_support.camunda7.dto.response.HistoricUserTaskDto
 import io.openbpm.control.test_support.camunda7.dto.response.RuntimeProcessInstanceDto;
 import io.openbpm.control.test_support.camunda7.dto.response.RuntimeUserTaskDto;
 import io.openbpm.control.test_support.camunda7.dto.response.VariableInstanceDto;
-import org.camunda.community.rest.exception.RemoteProcessEngineException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
1. Add a custom CamundaFeignErrorDecoder that handles Camunda REST error responses and contains a specific handling of ParseException error response
2. Replace RemoteProcessEngineException with the custom RemoteProcessEngineException containing response error message and type
3. Add DeploymentErrorDialogView to show the errors occurred during deployment and returned by Camunda
4. Add support of opening the DeploymentErrorDialogView in NewProcessDeploymentView and DecisionDeploymentView