### PR TITLE
Number of running processes on diagram element #58

### DIFF
--- a/src/main/frontend/themes/openbpm-control/view/process-definition-detail-view.css
+++ b/src/main/frontend/themes/openbpm-control/view/process-definition-detail-view.css
@@ -40,3 +40,8 @@
     float: right;
     position: absolute;
 }
+
+.process-details-diagram-box .bpmn-viewer-left-side-actions {
+    float: left;
+    position: absolute;
+}

--- a/src/main/java/io/openbpm/control/entity/activity/ProcessActivityStatistics.java
+++ b/src/main/java/io/openbpm/control/entity/activity/ProcessActivityStatistics.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.entity.activity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.openbpm.control.entity.dashboard.IncidentStatistics;
+
+import java.util.List;
+import java.util.UUID;
+
+@JmixEntity
+public class ProcessActivityStatistics {
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    private String activityId;
+
+    private Integer instanceCount;
+
+    private Integer failedJobCount;
+
+    private List<IncidentStatistics> incidents;
+
+    public List<IncidentStatistics> getIncidents() {
+        return incidents;
+    }
+
+    public void setIncidents(List<IncidentStatistics> incidents) {
+        this.incidents = incidents;
+    }
+
+    public Integer getFailedJobCount() {
+        return failedJobCount;
+    }
+
+    public void setFailedJobCount(Integer failedJobCount) {
+        this.failedJobCount = failedJobCount;
+    }
+
+    public String getActivityId() {
+        return activityId;
+    }
+
+    public void setActivityId(String activityId) {
+        this.activityId = activityId;
+    }
+
+    public Integer getInstanceCount() {
+        return instanceCount;
+    }
+
+    public void setInstanceCount(Integer instanceCount) {
+        this.instanceCount = instanceCount;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+}

--- a/src/main/java/io/openbpm/control/entity/filter/ProcessInstanceFilter.java
+++ b/src/main/java/io/openbpm/control/entity/filter/ProcessInstanceFilter.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @JmixEntity
@@ -44,6 +45,8 @@ public class ProcessInstanceFilter {
     protected Boolean withIncidents;
 
     protected Boolean unfinished;
+
+    protected List<String> activeActivityIdIn;
 
     public Boolean getUnfinished() {
         return unfinished;

--- a/src/main/java/io/openbpm/control/entity/processinstance/ProcessInstanceData.java
+++ b/src/main/java/io/openbpm/control/entity/processinstance/ProcessInstanceData.java
@@ -15,23 +15,11 @@ import io.jmix.core.metamodel.annotation.JmixProperty;
 import java.util.Date;
 
 @JmixEntity(name = "bpm_ProcessInstanceData")
-public class ProcessInstanceData {
-
-    @JmixId
-    @JmixProperty(mandatory = true)
-    protected String id;
+public class ProcessInstanceData  extends RuntimeProcessInstanceData {
 
     protected String deleteReason;
 
-    protected String instanceId;
-
-    protected Boolean suspended = false;
-
-    protected String businessKey;
-
     protected String tenantId;
-
-    protected String processDefinitionId;
 
     protected String processDefinitionKey;
 
@@ -51,16 +39,6 @@ public class ProcessInstanceData {
 
     protected Boolean externallyTerminated = false;
 
-    protected Boolean hasIncidents = false;
-
-    public Boolean getHasIncidents() {
-        return hasIncidents;
-    }
-
-    public void setHasIncidents(Boolean hasIncidents) {
-        this.hasIncidents = hasIncidents;
-    }
-
     public String getDeleteReason() {
         return deleteReason;
     }
@@ -69,52 +47,12 @@ public class ProcessInstanceData {
         this.deleteReason = deleteReason;
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getInstanceId() {
-        return instanceId;
-    }
-
-    public void setInstanceId(String instanceId) {
-        this.instanceId = instanceId;
-    }
-
-    public Boolean getSuspended() {
-        return suspended;
-    }
-
-    public void setSuspended(Boolean suspended) {
-        this.suspended = suspended;
-    }
-
-    public String getBusinessKey() {
-        return businessKey;
-    }
-
-    public void setBusinessKey(String businessKey) {
-        this.businessKey = businessKey;
-    }
-
     public String getTenantId() {
         return tenantId;
     }
 
     public void setTenantId(String tenantId) {
         this.tenantId = tenantId;
-    }
-
-    public String getProcessDefinitionId() {
-        return processDefinitionId;
-    }
-
-    public void setProcessDefinitionId(String processDefinitionId) {
-        this.processDefinitionId = processDefinitionId;
     }
 
     public String getProcessDefinitionKey() {

--- a/src/main/java/io/openbpm/control/entity/processinstance/RuntimeProcessInstanceData.java
+++ b/src/main/java/io/openbpm/control/entity/processinstance/RuntimeProcessInstanceData.java
@@ -1,0 +1,33 @@
+package io.openbpm.control.entity.processinstance;
+
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.JmixProperty;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+
+@JmixEntity
+@Getter
+@Setter
+public class RuntimeProcessInstanceData {
+
+    @JmixId
+    @JmixProperty(mandatory = true)
+    protected String id;
+
+    protected String instanceId;
+
+    protected String businessKey;
+
+    protected String processDefinitionId;
+
+    protected Boolean suspended = false;
+
+    protected Boolean hasIncidents = false;
+
+    @JmixProperty
+    public ProcessInstanceState getState() {
+        return BooleanUtils.isTrue(suspended) ? ProcessInstanceState.SUSPENDED : ProcessInstanceState.ACTIVE;
+    }
+}

--- a/src/main/java/io/openbpm/control/mapper/ActivityMapper.java
+++ b/src/main/java/io/openbpm/control/mapper/ActivityMapper.java
@@ -8,8 +8,12 @@ package io.openbpm.control.mapper;
 import io.openbpm.control.entity.activity.ActivityShortData;
 import io.openbpm.control.entity.activity.ActivityInstanceTreeItem;
 import io.jmix.core.Metadata;
+import io.openbpm.control.entity.activity.ProcessActivityStatistics;
+import io.openbpm.control.entity.dashboard.IncidentStatistics;
 import org.camunda.community.rest.client.model.ActivityInstanceDto;
+import org.camunda.community.rest.client.model.ActivityStatisticsResultDto;
 import org.camunda.community.rest.client.model.HistoricActivityInstanceDto;
+import org.camunda.community.rest.client.model.IncidentStatisticsResultDto;
 import org.camunda.community.rest.client.model.TransitionInstanceDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -55,5 +59,22 @@ public abstract class ActivityMapper {
         }
         Instant instant = value.toInstant();
         return Date.from(instant);
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "instanceCount", source = "instances")
+    @Mapping(target = "failedJobCount", source = "failedJobs")
+    @Mapping(target = "activityId", source = "id")
+    public abstract ProcessActivityStatistics fromActivityStatisticsResult(ActivityStatisticsResultDto source);
+
+    ProcessActivityStatistics activityStatisticsClassFactory() {
+        return metadata.create(ProcessActivityStatistics.class);
+    }
+
+    @Mapping(target = "id", ignore = true)
+    public abstract IncidentStatistics fromStatisticsResultDto(IncidentStatisticsResultDto resultDto);
+
+    IncidentStatistics incidentStatisticsClassFactory() {
+        return metadata.create(IncidentStatistics.class);
     }
 }

--- a/src/main/java/io/openbpm/control/mapper/ProcessInstanceMapper.java
+++ b/src/main/java/io/openbpm/control/mapper/ProcessInstanceMapper.java
@@ -7,12 +7,14 @@ package io.openbpm.control.mapper;
 
 import io.jmix.core.Metadata;
 import io.openbpm.control.entity.processinstance.ProcessInstanceData;
+import io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.community.rest.client.model.HistoricProcessInstanceDto;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.TargetType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 
@@ -37,10 +39,6 @@ public abstract class ProcessInstanceMapper {
     @Mapping(target = "processDefinitionVersion", ignore = true)
     @Mapping(target = "deleteReason", ignore = true)
     public abstract ProcessInstanceData fromProcessInstanceModel(ProcessInstance source);
-
-    ProcessInstanceData targetClassFactory() {
-        return metadata.create(ProcessInstanceData.class);
-    }
 
     @Mapping(target = "hasIncidents", ignore = true)
     @Mapping(target = "instanceId", source = "id")
@@ -67,5 +65,13 @@ public abstract class ProcessInstanceMapper {
             default -> {
             }
         }
+    }
+
+    @Mapping(target = "hasIncidents", ignore = true)
+    @Mapping(target = "instanceId", source = "id")
+    public abstract RuntimeProcessInstanceData toRuntimeProcessInstanceData(ProcessInstance source);
+
+    public <T extends RuntimeProcessInstanceData> T createProcessInstanceData(@TargetType Class<T> processInstanceClass) {
+        return metadata.create(processInstanceClass);
     }
 }

--- a/src/main/java/io/openbpm/control/service/activity/ActivityService.java
+++ b/src/main/java/io/openbpm/control/service/activity/ActivityService.java
@@ -8,6 +8,7 @@ package io.openbpm.control.service.activity;
 import io.openbpm.control.entity.activity.ActivityInstanceTreeItem;
 import io.openbpm.control.entity.activity.ActivityShortData;
 import io.openbpm.control.entity.activity.HistoricActivityInstanceData;
+import io.openbpm.control.entity.activity.ProcessActivityStatistics;
 import io.openbpm.control.entity.filter.ActivityFilter;
 import org.springframework.lang.Nullable;
 
@@ -66,4 +67,12 @@ public interface ActivityService {
      */
     @Nullable
     HistoricActivityInstanceData findById(String activityInstanceId);
+
+    /**
+     * Loads the statistics (count of running instances, incidents) for the specified process definition.
+     *
+     * @param processDefinitionId an id of the process definition for which the statistics should be loaded
+     * @return found process statistics
+     */
+    List<ProcessActivityStatistics> getStatisticsByProcessId(String processDefinitionId);
 }

--- a/src/main/java/io/openbpm/control/service/processinstance/ProcessInstanceLoadContext.java
+++ b/src/main/java/io/openbpm/control/service/processinstance/ProcessInstanceLoadContext.java
@@ -8,6 +8,7 @@ package io.openbpm.control.service.processinstance;
 import io.jmix.core.Sort;
 import io.openbpm.control.entity.filter.ProcessInstanceFilter;
 import io.openbpm.control.service.ItemListLoadContext;
+import lombok.Getter;
 
 /**
  * A context that contains the following options to load incidents:
@@ -34,7 +35,10 @@ import io.openbpm.control.service.ItemListLoadContext;
  * @see io.jmix.core.Metadata
  * @see Sort
  */
+@Getter
 public class ProcessInstanceLoadContext extends ItemListLoadContext<ProcessInstanceFilter> {
+
+    protected boolean loadIncidents;
 
     /**
      * Sets a process instance filter.
@@ -77,6 +81,17 @@ public class ProcessInstanceLoadContext extends ItemListLoadContext<ProcessInsta
      */
     public ProcessInstanceLoadContext setSort(Sort sort) {
         this.sort = sort;
+        return this;
+    }
+
+    /**
+     * Sets a flag that allows to load incidents for the state.
+     *
+     * @param loadIncidents needs to load incidents to mark the instance state.
+     * @return current context
+     */
+    public ProcessInstanceLoadContext setLoadIncidents(boolean loadIncidents) {
+        this.loadIncidents = loadIncidents;
         return this;
     }
 }

--- a/src/main/java/io/openbpm/control/service/processinstance/ProcessInstanceService.java
+++ b/src/main/java/io/openbpm/control/service/processinstance/ProcessInstanceService.java
@@ -7,6 +7,7 @@ package io.openbpm.control.service.processinstance;
 
 import io.openbpm.control.entity.filter.ProcessInstanceFilter;
 import io.openbpm.control.entity.processinstance.ProcessInstanceData;
+import io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData;
 import io.openbpm.control.entity.variable.VariableInstanceData;
 import org.springframework.lang.Nullable;
 
@@ -26,6 +27,15 @@ public interface ProcessInstanceService {
      */
     List<ProcessInstanceData> findAllHistoricInstances(ProcessInstanceLoadContext loadContext);
 
+
+    /**
+     * Loads process instances from the engine runtime data using the specified context.
+     *
+     * @param loadContext a context to load process instances
+     * @return a list of process instances
+     */
+    List<RuntimeProcessInstanceData> findAllRuntimeInstances(ProcessInstanceLoadContext loadContext);
+
     /**
      * Loads from the engine history the total count of process instances that match the specified filter.
      *
@@ -33,6 +43,15 @@ public interface ProcessInstanceService {
      * @return count of process instances
      */
     long getHistoricInstancesCount(ProcessInstanceFilter filter);
+
+    /**
+     * Loads from the engine history the total count of process instances that match the specified filter.
+     *
+     * @param filter a process instance filter
+     * @return count of process instances
+     */
+    long getRuntimeInstancesCount(ProcessInstanceFilter filter);
+
 
     /**
      * Loads a process instance with the specified identifier.

--- a/src/main/java/io/openbpm/control/util/QueryUtils.java
+++ b/src/main/java/io/openbpm/control/util/QueryUtils.java
@@ -53,6 +53,7 @@ public class QueryUtils {
         addIfTrue(filter.getSuspended(), processInstanceQuery::suspended);
         addIfTrue(filter.getWithIncidents(), processInstanceQuery::withIncident);
 
+        addIfNotNull(filter.getActiveActivityIdIn(), activityList -> processInstanceQuery.activityIdIn(activityList.toArray(new String[0])));
     }
 
     public static void addRuntimeSort(ProcessInstanceQuery processInstanceQuery, @Nullable Sort sort) {
@@ -96,6 +97,7 @@ public class QueryUtils {
         addIfNotNull(filter.getStartTimeBefore(), queryDto::startedBefore);
         addIfNotNull(filter.getEndTimeAfter(), queryDto::finishedAfter);
         addIfNotNull(filter.getEndTimeBefore(), queryDto::finishedBefore);
+        addIfNotNull(filter.getActiveActivityIdIn(), queryDto::activeActivityIdIn);
     }
 
     public static void addHistorySort(HistoricProcessInstanceQueryDto queryDto, @Nullable Sort sort) {

--- a/src/main/java/io/openbpm/control/view/processdefinition/event/ResetActivityEvent.java
+++ b/src/main/java/io/openbpm/control/view/processdefinition/event/ResetActivityEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.processdefinition.event;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Resets a filter with the selected activity.
+ */
+public class ResetActivityEvent extends ApplicationEvent {
+    private final String activityId;
+
+    public ResetActivityEvent(Object source, String activityId) {
+        super(source);
+        this.activityId = activityId;
+    }
+
+    public String getActivityId() {
+        return activityId;
+    }
+}

--- a/src/main/java/io/openbpm/control/view/processinstance/ProcessInstanceListView.java
+++ b/src/main/java/io/openbpm/control/view/processinstance/ProcessInstanceListView.java
@@ -211,7 +211,9 @@ public class ProcessInstanceListView extends StandardListView<ProcessInstanceDat
         LoadContext.Query query = loadContext.getQuery();
         ProcessInstanceFilter filter = processInstanceFilterDc.getItemOrNull();
 
-        ProcessInstanceLoadContext context = new ProcessInstanceLoadContext().setFilter(filter);
+        ProcessInstanceLoadContext context = new ProcessInstanceLoadContext().setFilter(filter)
+                .setLoadIncidents(true);
+
         if (query != null) {
             context = context.setFirstResult(query.getFirstResult())
                     .setMaxResults(query.getMaxResults())

--- a/src/main/java/io/openbpm/control/view/processinstance/column/instanceid/InstanceIdColumnFragment.java
+++ b/src/main/java/io/openbpm/control/view/processinstance/column/instanceid/InstanceIdColumnFragment.java
@@ -9,10 +9,10 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import io.jmix.flowui.fragment.FragmentDescriptor;
 import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
 import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
-import io.openbpm.control.entity.processinstance.ProcessInstanceData;
+import io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData;
 
 @FragmentDescriptor("instance-id-column-fragment.xml")
 @RendererItemContainer("processInstanceDc")
-public class InstanceIdColumnFragment extends FragmentRenderer<HorizontalLayout, ProcessInstanceData> {
+public class InstanceIdColumnFragment extends FragmentRenderer<HorizontalLayout, RuntimeProcessInstanceData> {
 
 }

--- a/src/main/java/io/openbpm/control/view/processinstance/column/state/ProcessInstanceStateColumnFragment.java
+++ b/src/main/java/io/openbpm/control/view/processinstance/column/state/ProcessInstanceStateColumnFragment.java
@@ -1,4 +1,9 @@
-package io.openbpm.control.view.processinstance;
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.processinstance.column.state;
 
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
@@ -7,14 +12,14 @@ import io.jmix.flowui.fragment.FragmentDescriptor;
 import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
 import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
 import io.jmix.flowui.view.ViewComponent;
-import io.openbpm.control.entity.processinstance.ProcessInstanceData;
+import io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData;
 import io.openbpm.control.view.util.ComponentHelper;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @FragmentDescriptor("process-instance-state-column-fragment.xml")
 @RendererItemContainer("processInstanceDataDc")
-public class ProcessInstanceStateColumnFragment extends FragmentRenderer<HorizontalLayout, ProcessInstanceData> {
+public class ProcessInstanceStateColumnFragment extends FragmentRenderer<HorizontalLayout, RuntimeProcessInstanceData> {
 
     @Autowired
     protected ComponentHelper componentHelper;
@@ -22,7 +27,7 @@ public class ProcessInstanceStateColumnFragment extends FragmentRenderer<Horizon
     protected Icon incidentIcon;
 
     @Override
-    public void setItem(ProcessInstanceData item) {
+    public void setItem(RuntimeProcessInstanceData item) {
         super.setItem(item);
 
         Span processInstanceStateBadge = componentHelper.createProcessInstanceStateBadge(item.getState());

--- a/src/main/resources/io/openbpm/control/messages_de.properties
+++ b/src/main/resources/io/openbpm/control/messages_de.properties
@@ -118,6 +118,10 @@ io.openbpm.control.entity.processinstance/ProcessInstanceState=Prozessinstanzsta
 io.openbpm.control.entity.processinstance/ProcessInstanceState.ACTIVE=Laufend
 io.openbpm.control.entity.processinstance/ProcessInstanceState.COMPLETED=Abgeschlossen
 io.openbpm.control.entity.processinstance/ProcessInstanceState.SUSPENDED=Angehalten
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.businessKey=Geschäftsschlüssel
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.id=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.instanceId=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.state=Zustand
 
 io.openbpm.control.entity/User=Benutzer
 io.openbpm.control.entity/User.id=ID
@@ -482,6 +486,7 @@ io.openbpm.control.view.processdefinition/processInstancesTab.defaultLabel=Proze
 io.openbpm.control.view.processdefinition/processInstancesTab.label=Prozessinstanzen (%s)
 io.openbpm.control.view.processdefinition/processesDeleted=Prozesse erfolgreich gelöscht
 io.openbpm.control.view.processdefinition/selectState=Status auswählen
+io.openbpm.control.view.processdefinition/selectedActivityBadge.text=Aktivität: %s
 io.openbpm.control.view.processdefinition/spanText=Alle laufenden Instanzen
 io.openbpm.control.view.processdefinition/startProcess.success=Der Prozess '%s' wurde gestartet
 io.openbpm.control.view.processdefinition/startProcessBtn.title=Prozessinstanz starten
@@ -526,7 +531,6 @@ io.openbpm.control.view.processinstance/processDefinition=Prozess
 
 io.openbpm.control.view.processinstance/processInstanceDetailView.baseTitle=Prozessinstanz
 io.openbpm.control.view.processinstance/processInstanceDetailView.title=Prozessinstanz "%s"
-io.openbpm.control.view.processinstance/processInstanceIncidentTooltip=Prozessinstanz hat Vorfall/Vorfälle
 io.openbpm.control.view.processinstance/runtimeTabCaption=Laufzeit
 
 io.openbpm.control.view.processinstance/processInstanceActivated=Prozessinstanz aktiviert
@@ -565,6 +569,9 @@ io.openbpm.control.view.processinstance.filter/processInstanceId.placeholder=Wer
 io.openbpm.control.view.processdefinitionsstatistics/instanceCount=Instanzanzahl
 io.openbpm.control.view.processdefinitionsstatistics/process=Prozess
 io.openbpm.control.view.processdefinitionsstatistics/processDefinitionsStatisticsView.title=Laufende Prozesse
+
+io.openbpm.control.view.processinstance.column.state/processInstanceIncidentTooltip=Prozessinstanz hat Vorfall/Vorfälle
+
 
 io.openbpm.control.view.processinstance.filter/businessKey.placeholder=Wert eingeben
 io.openbpm.control.view.processinstance.filter/processVersionFilterLabel=Prozessversion
@@ -656,6 +663,12 @@ io.openbpm.control.entity.activity/HistoricActivityInstanceData.processDefinitio
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.processInstanceId=Prozessinstanz-ID
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.startTime=Startzeit
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.taskId=Aufgaben-ID
+io.openbpm.control.entity.activity/ProcessActivityStatistics=Process activity statistics
+io.openbpm.control.entity.activity/ProcessActivityStatistics.activityId=Activity id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.failedJobCount=Failed job count
+io.openbpm.control.entity.activity/ProcessActivityStatistics.id=Id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.incidents=Incidents
+io.openbpm.control.entity.activity/ProcessActivityStatistics.instanceCount=Instance count
 
 io.openbpm.control.entity.deployment/DeploymentData=Deploymentdaten
 io.openbpm.control.entity.deployment/DeploymentData.deploymentId=Deployment-ID

--- a/src/main/resources/io/openbpm/control/messages_en.properties
+++ b/src/main/resources/io/openbpm/control/messages_en.properties
@@ -118,6 +118,10 @@ io.openbpm.control.entity.processinstance/ProcessInstanceState=Process instance 
 io.openbpm.control.entity.processinstance/ProcessInstanceState.ACTIVE=Running
 io.openbpm.control.entity.processinstance/ProcessInstanceState.COMPLETED=Completed
 io.openbpm.control.entity.processinstance/ProcessInstanceState.SUSPENDED=Suspended
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.businessKey=Business key
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.id=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.instanceId=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.state=State
 
 
 io.openbpm.control.entity/User=User
@@ -491,6 +495,7 @@ io.openbpm.control.view.processdefinition/processInstancesTab.defaultLabel=Proce
 io.openbpm.control.view.processdefinition/processInstancesTab.label=Process instances (%s)
 io.openbpm.control.view.processdefinition/processesDeleted=Processes deleted successfully
 io.openbpm.control.view.processdefinition/selectState=Select a state
+io.openbpm.control.view.processdefinition/selectedActivityBadge.text=Activity: %s
 io.openbpm.control.view.processdefinition/spanText=All running instances
 io.openbpm.control.view.processdefinition/startProcess.success=The '%s' process started
 io.openbpm.control.view.processdefinition/startProcessBtn.title=Start process instance
@@ -537,7 +542,6 @@ io.openbpm.control.view.processinstance/processDefinition=Process
 
 io.openbpm.control.view.processinstance/processInstanceDetailView.baseTitle=Process instance
 io.openbpm.control.view.processinstance/processInstanceDetailView.title=Process instance "%s"
-io.openbpm.control.view.processinstance/processInstanceIncidentTooltip=Process instance has incident(s)
 io.openbpm.control.view.processinstance/runtimeTabCaption=Runtime
 
 io.openbpm.control.view.processinstance/activateDialog.header=Activate process instance
@@ -578,6 +582,9 @@ io.openbpm.control.view.processinstance.filter/processInstanceId.placeholder=Ent
 io.openbpm.control.view.processdefinitionsstatistics/instanceCount=Instance count
 io.openbpm.control.view.processdefinitionsstatistics/process=Process
 io.openbpm.control.view.processdefinitionsstatistics/processDefinitionsStatisticsView.title=Running processes
+
+io.openbpm.control.view.processinstance.column.state/processInstanceIncidentTooltip=Process instance has incident(s)
+
 
 io.openbpm.control.view.processinstance.filter/businessKey.placeholder=Enter a value
 io.openbpm.control.view.processinstance.filter/processVersionFilterLabel=Process version
@@ -670,6 +677,12 @@ io.openbpm.control.entity.activity/HistoricActivityInstanceData.processDefinitio
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.processInstanceId=Process instance Id
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.startTime=Start time
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.taskId=Task Id
+io.openbpm.control.entity.activity/ProcessActivityStatistics=Process activity statistics
+io.openbpm.control.entity.activity/ProcessActivityStatistics.activityId=Activity id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.failedJobCount=Failed job count
+io.openbpm.control.entity.activity/ProcessActivityStatistics.id=Id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.incidents=Incidents
+io.openbpm.control.entity.activity/ProcessActivityStatistics.instanceCount=Instance count
 
 io.openbpm.control.entity.deployment/DeploymentData=Deployment data
 io.openbpm.control.entity.deployment/DeploymentData.deploymentId=Deployment id

--- a/src/main/resources/io/openbpm/control/messages_es.properties
+++ b/src/main/resources/io/openbpm/control/messages_es.properties
@@ -118,6 +118,10 @@ io.openbpm.control.entity.processinstance/ProcessInstanceState=Estado de la inst
 io.openbpm.control.entity.processinstance/ProcessInstanceState.ACTIVE=En ejecución
 io.openbpm.control.entity.processinstance/ProcessInstanceState.COMPLETED=Completado
 io.openbpm.control.entity.processinstance/ProcessInstanceState.SUSPENDED=Suspendido
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.businessKey=Clave de negocio
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.id=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.instanceId=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.state=Estado
 
 io.openbpm.control.entity/User=Usuario
 io.openbpm.control.entity/User.id=ID
@@ -484,6 +488,7 @@ io.openbpm.control.view.processdefinition/processInstancesTab.defaultLabel=Insta
 io.openbpm.control.view.processdefinition/processInstancesTab.label=Instancias de proceso (%s)
 io.openbpm.control.view.processdefinition/processesDeleted=Procesos eliminados correctamente
 io.openbpm.control.view.processdefinition/selectState=Seleccionar estado
+io.openbpm.control.view.processdefinition/selectedActivityBadge.text=Actividad: %s
 io.openbpm.control.view.processdefinition/spanText=Todas las instancias en ejecución
 io.openbpm.control.view.processdefinition/startProcess.success=El proceso '%s' ha sido iniciado
 io.openbpm.control.view.processdefinition/startProcessBtn.title=Iniciar instancia de proceso
@@ -528,7 +533,6 @@ io.openbpm.control.view.processinstance/processDefinition=Proceso
 
 io.openbpm.control.view.processinstance/processInstanceDetailView.baseTitle=Instancia de proceso
 io.openbpm.control.view.processinstance/processInstanceDetailView.title=Instancia de proceso "%s"
-io.openbpm.control.view.processinstance/processInstanceIncidentTooltip=La instancia de proceso tiene incidente(s)
 io.openbpm.control.view.processinstance/runtimeTabCaption=Ejecución
 
 io.openbpm.control.view.processinstance/processInstanceActivated=Instancia de proceso activada
@@ -568,6 +572,9 @@ io.openbpm.control.view.processinstance.filter/processInstanceId.placeholder=Int
 io.openbpm.control.view.processdefinitionsstatistics/instanceCount=Conteo de instancias
 io.openbpm.control.view.processdefinitionsstatistics/process=Proceso
 io.openbpm.control.view.processdefinitionsstatistics/processDefinitionsStatisticsView.title=Procesos en ejecución
+
+io.openbpm.control.view.processinstance.column.state/processInstanceIncidentTooltip=La instancia de proceso tiene incidente(s)
+
 
 io.openbpm.control.view.processinstance.filter/businessKey.placeholder=Introduzca un valor
 io.openbpm.control.view.processinstance.filter/processVersionFilterLabel=Versión del proceso
@@ -659,6 +666,12 @@ io.openbpm.control.entity.activity/HistoricActivityInstanceData.processDefinitio
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.processInstanceId=Id de instancia de proceso
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.startTime=Hora de inicio
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.taskId=Id de tarea
+io.openbpm.control.entity.activity/ProcessActivityStatistics=Process activity statistics
+io.openbpm.control.entity.activity/ProcessActivityStatistics.activityId=Activity id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.failedJobCount=Failed job count
+io.openbpm.control.entity.activity/ProcessActivityStatistics.id=Id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.incidents=Incidents
+io.openbpm.control.entity.activity/ProcessActivityStatistics.instanceCount=Instance count
 
 io.openbpm.control.entity.deployment/DeploymentData=Datos de despliegue
 io.openbpm.control.entity.deployment/DeploymentData.deploymentId=Id de despliegue

--- a/src/main/resources/io/openbpm/control/messages_ru.properties
+++ b/src/main/resources/io/openbpm/control/messages_ru.properties
@@ -112,6 +112,10 @@ io.openbpm.control.entity.processinstance/ProcessInstanceState=Состояни�
 io.openbpm.control.entity.processinstance/ProcessInstanceState.ACTIVE=В работе
 io.openbpm.control.entity.processinstance/ProcessInstanceState.COMPLETED=Завершен
 io.openbpm.control.entity.processinstance/ProcessInstanceState.SUSPENDED=Приостановлен
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.businessKey=Бизнес ключ
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.id=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.instanceId=Id
+io.openbpm.control.entity.processinstance/RuntimeProcessInstanceData.state=Состояние
 
 
 io.openbpm.control.entity/User=Пользователь
@@ -486,6 +490,7 @@ io.openbpm.control.view.processdefinition/processInstancesTab.defaultLabel=Эк�
 io.openbpm.control.view.processdefinition/processInstancesTab.label=Экземпляры процесса (%s)
 io.openbpm.control.view.processdefinition/processesDeleted=Процессы успешно удалены
 io.openbpm.control.view.processdefinition/selectState=Выберите состояние
+io.openbpm.control.view.processdefinition/selectedActivityBadge.text=Активность: %s
 io.openbpm.control.view.processdefinition/spanText=Все запущенные экземпляры
 io.openbpm.control.view.processdefinition/startProcess.success=Процесс '%s' запущен
 io.openbpm.control.view.processdefinition/startProcessBtn.title=Запустить экземпляр процесса
@@ -533,7 +538,6 @@ io.openbpm.control.view.processinstance/processDefinition=Процесс
 
 io.openbpm.control.view.processinstance/processInstanceDetailView.baseTitle=Экземпляр процесса
 io.openbpm.control.view.processinstance/processInstanceDetailView.title=Экземпляр процесса "%s"
-io.openbpm.control.view.processinstance/processInstanceIncidentTooltip=В экземпляре процесса есть инциденты
 io.openbpm.control.view.processinstance/runtimeTabCaption=Состояние
 
 io.openbpm.control.view.processinstance/suspendDialog.header=Приостановка экземпляра процесса
@@ -576,6 +580,9 @@ io.openbpm.control.view.processinstance.filter/processInstanceId.placeholder=В�
 io.openbpm.control.view.processdefinitionsstatistics/instanceCount=Количество экземпляров
 io.openbpm.control.view.processdefinitionsstatistics/process=Процесс
 io.openbpm.control.view.processdefinitionsstatistics/processDefinitionsStatisticsView.title=Запущенные процессы
+
+io.openbpm.control.view.processinstance.column.state/processInstanceIncidentTooltip=В экземпляре процесса есть инциденты
+
 
 io.openbpm.control.view.processinstance.filter/businessKey.placeholder=Введите значение
 
@@ -670,6 +677,12 @@ io.openbpm.control.entity.activity/HistoricActivityInstanceData.processDefinitio
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.processInstanceId=Id экземпляра процесса
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.startTime=Дата начала
 io.openbpm.control.entity.activity/HistoricActivityInstanceData.taskId=Id задачи
+io.openbpm.control.entity.activity/ProcessActivityStatistics=Process activity statistics
+io.openbpm.control.entity.activity/ProcessActivityStatistics.activityId=Activity id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.failedJobCount=Failed job count
+io.openbpm.control.entity.activity/ProcessActivityStatistics.id=Id
+io.openbpm.control.entity.activity/ProcessActivityStatistics.incidents=Incidents
+io.openbpm.control.entity.activity/ProcessActivityStatistics.instanceCount=Instance count
 
 io.openbpm.control.entity.deployment/DeploymentData=Данные развертывания
 io.openbpm.control.entity.deployment/DeploymentData.id=Id

--- a/src/main/resources/io/openbpm/control/view/processdefinition/process-definition-detail-view.xml
+++ b/src/main/resources/io/openbpm/control/view/processdefinition/process-definition-detail-view.xml
@@ -11,9 +11,13 @@
             <loader id="processDefinitionDataDl"/>
         </instance>
         <collection id="processInstanceDataDc"
-                    class="io.openbpm.control.entity.processinstance.ProcessInstanceData">
+                    class="io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData">
             <loader id="processInstanceDataDl"/>
         </collection>
+        <instance id="processInstanceFilterDc" class="io.openbpm.control.entity.filter.ProcessInstanceFilter">
+            <loader id="processInstanceFilterDl"/>
+            <fetchPlan extends="_base"/>
+        </instance>
     </data>
     <facets>
         <dataLoadCoordinator auto="true"/>

--- a/src/main/resources/io/openbpm/control/view/processdefinition/process-instances-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/processdefinition/process-instances-fragment.xml
@@ -7,13 +7,15 @@
     <data>
         <instance id="processDefinitionDataDc" class="io.openbpm.control.entity.processdefinition.ProcessDefinitionData" provided="true"/>
         <collection id="processInstanceDataDc"
-                    class="io.openbpm.control.entity.processinstance.ProcessInstanceData" provided="true"/>
+                    class="io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData" provided="true"/>
+        <instance id="processInstanceFilterDc" class="io.openbpm.control.entity.filter.ProcessInstanceFilter" provided="true"/>
     </data>
     <content>
         <vbox id="processInstanceVBox" width="100%" height="100%" themeNames="spacing-xs" padding="false">
             <hbox id="processInstancesButtons" classNames="buttons-panel" alignItems="BASELINE">
                 <button id="refreshProcessInstanceBtn" action="processInstancesGrid.refresh"
                         themeNames="small success primary"/>
+                <div id="selectedActivityContainer"/>
                 <simplePagination id="processInstancesPagination" />
             </hbox>
             <dataGrid id="processInstancesGrid" dataContainer="processInstanceDataDc" themeNames="compact"
@@ -27,10 +29,11 @@
                     <column property="id" autoWidth="true" flexGrow="1">
                         <fragmentRenderer class="io.openbpm.control.view.processinstance.column.instanceid.InstanceIdColumnFragment"/>
                     </column>
-                    <column property="startTime" autoWidth="true" flexGrow="0"/>
                     <column property="businessKey" autoWidth="true" flexGrow="2"/>
                     <column key="state" header="msg://processInstance.state" autoWidth="true" flexGrow="1"
-                            sortable="false"/>
+                            sortable="false">
+                        <fragmentRenderer class="io.openbpm.control.view.processinstance.column.state.ProcessInstanceStateColumnFragment"/>
+                    </column>
                     <column key="actions" sortable="false" flexGrow="0" autoWidth="true"/>
                 </columns>
             </dataGrid>

--- a/src/main/resources/io/openbpm/control/view/processinstance/column/instanceid/instance-id-column-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/processinstance/column/instanceid/instance-id-column-fragment.xml
@@ -6,7 +6,7 @@
 
 <fragment xmlns="http://jmix.io/schema/flowui/fragment">
     <data>
-        <instance id="processInstanceDc" class="io.openbpm.control.entity.processinstance.ProcessInstanceData">
+        <instance id="processInstanceDc" class="io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData">
             <loader id="processInstanceDl"/>
         </instance>
     </data>

--- a/src/main/resources/io/openbpm/control/view/processinstance/column/state/process-instance-state-column-fragment.xml
+++ b/src/main/resources/io/openbpm/control/view/processinstance/column/state/process-instance-state-column-fragment.xml
@@ -1,6 +1,11 @@
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
 <fragment xmlns="http://jmix.io/schema/flowui/fragment">
     <data readOnly="true">
-        <instance id="processInstanceDataDc" class="io.openbpm.control.entity.processinstance.ProcessInstanceData"/>
+        <instance id="processInstanceDataDc" class="io.openbpm.control.entity.processinstance.RuntimeProcessInstanceData"/>
     </data>
     <content>
         <hbox padding="false" themeNames="spacing-xs" classNames="mt-xs mb-xs" width="max-content" alignItems="BASELINE">

--- a/src/main/resources/io/openbpm/control/view/processinstance/process-instance-list-view.xml
+++ b/src/main/resources/io/openbpm/control/view/processinstance/process-instance-list-view.xml
@@ -50,7 +50,7 @@
                 <column property="businessKey" flexGrow="1" autoWidth="true"/>
                 <column property="state" sortable="false" autoWidth="true" flexGrow="1">
                     <fragmentRenderer
-                            class="io.openbpm.control.view.processinstance.ProcessInstanceStateColumnFragment"/>
+                            class="io.openbpm.control.view.processinstance.column.state.ProcessInstanceStateColumnFragment"/>
                 </column>
                 <column property="startTime" autoWidth="true"/>
                 <column property="endTime" flexGrow="1" autoWidth="true"/>

--- a/src/test/java/io/openbpm/control/service/activity/Camunda7ActivityServiceTest.java
+++ b/src/test/java/io/openbpm/control/service/activity/Camunda7ActivityServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.service.activity;
+
+import io.openbpm.control.entity.activity.ProcessActivityStatistics;
+import io.openbpm.control.test_support.AuthenticatedAsAdmin;
+import io.openbpm.control.test_support.RunningEngine;
+import io.openbpm.control.test_support.WithRunningEngine;
+import io.openbpm.control.test_support.camunda7.AbstractCamunda7IntegrationTest;
+import io.openbpm.control.test_support.camunda7.Camunda7Container;
+import io.openbpm.control.test_support.camunda7.CamundaSampleDataManager;
+import io.openbpm.control.test_support.camunda7.dto.request.StartProcessDto;
+import io.openbpm.control.test_support.camunda7.dto.request.VariableValueDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@SpringBootTest
+@ExtendWith(AuthenticatedAsAdmin.class)
+@WithRunningEngine
+public class Camunda7ActivityServiceTest extends AbstractCamunda7IntegrationTest {
+    @RunningEngine
+    static Camunda7Container<?> camunda7;
+
+    @Autowired
+    ApplicationContext applicationContext;
+    @Autowired
+    ActivityService activityService;
+
+    @Test
+    @DisplayName("Load activity statistics by process definition id")
+    void givenProcessWithRunningInstances_whenGetStatisticsByProcessId_thenStatisticsReturned() {
+        // given
+        StartProcessDto startProcessDto = new StartProcessDto();
+        startProcessDto.setVariables(Map.of("fail",
+                new VariableValueDto("boolean", true)));
+
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testActivityStatistics.bpmn")
+                .startByKey("testActivityStatistics", 3)
+                .startByKey("testActivityStatistics", startProcessDto, 2)
+                .waitJobsExecution();
+
+        String processDefId = sampleDataManager.getDeployedProcessVersions("testActivityStatistics").getFirst();
+
+        // when
+        List<ProcessActivityStatistics> stats = activityService.getStatisticsByProcessId(processDefId);
+
+        // then
+        assertThat(stats).isNotEmpty()
+                .hasSize(2);
+
+        assertThat(stats)
+                .filteredOn("activityId", "testScriptTask")
+                .singleElement()
+                .satisfies(stat -> {
+                    assertThat(stat.getInstanceCount()).isEqualTo(2);
+                    assertThat(stat.getFailedJobCount()).isEqualTo(2);
+                    assertThat(stat.getIncidents())
+                            .hasSize(1)
+                            .extracting("incidentType", "incidentCount")
+                            .contains(tuple("failedJob", 2));
+                });
+
+        assertThat(stats)
+                .filteredOn("activityId", "testUserTask")
+                .singleElement()
+                .satisfies(stat -> {
+                    assertThat(stat.getInstanceCount()).isEqualTo(3);
+                    assertThat(stat.getFailedJobCount()).isZero();
+                    assertThat(stat.getIncidents()).isNullOrEmpty();
+                });
+    }
+}

--- a/src/test/resources/test_support/testActivityStatistics.bpmn
+++ b/src/test/resources/test_support/testActivityStatistics.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:jmix="http://jmix.io/schema/bpm/bpmn" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1bhfunt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="testActivityStatistics" name="testActivityStatistics" isExecutable="true" camunda:historyTimeToLive="P180D">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0wu3snj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0wu3snj" sourceRef="StartEvent_1" targetRef="testScriptTask" />
+    <bpmn:scriptTask id="testScriptTask" name="Test script task" scriptFormat="groovy" camunda:asyncBefore="true" camunda:exclusive="false">
+      <bpmn:incoming>Flow_0wu3snj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tmym9z</bpmn:outgoing>
+      <bpmn:script>fail = execution.getVariable('fail')
+
+if(fail != null) {
+  throw new RuntimeException("Unable to execute task")
+}</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1tmym9z" sourceRef="testScriptTask" targetRef="testUserTask" />
+    <bpmn:userTask id="testUserTask" name="Test user task">
+      <bpmn:incoming>Flow_1tmym9z</bpmn:incoming>
+      <bpmn:outgoing>Flow_151aqid</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_19ud1fc">
+      <bpmn:incoming>Flow_151aqid</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_151aqid" sourceRef="testUserTask" targetRef="Event_19ud1fc">
+      <bpmn:extensionElements>
+        <jmix:conditionDetails conditionSource="userTaskOutcome" />
+      </bpmn:extensionElements>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testActivityStatistics">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1csgb66_di" bpmnElement="testScriptTask">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_160ayuy_di" bpmnElement="testUserTask">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19ud1fc_di" bpmnElement="Event_19ud1fc">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0wu3snj_di" bpmnElement="Flow_0wu3snj">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tmym9z_di" bpmnElement="Flow_1tmym9z">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_151aqid_di" bpmnElement="Flow_151aqid">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
1. Add button to show/hide activity statistics (count of running instances and incidents) in diagram element in ProcessDefinitionDetailView. By default, activity statistics is displayed.
2. Load the statistics for current selected of the process version in ProcessDefinitionDetailView
3. Load instances from the engine runtime data instead of engine history in the Process instances tab.  It is required for correct loading of instances by the clicked activity with incidents.