### PR TITLE
Call activity navigation #60

### DIFF
--- a/src/main/java/io/openbpm/control/entity/activity/ActivityShortData.java
+++ b/src/main/java/io/openbpm/control/entity/activity/ActivityShortData.java
@@ -30,6 +30,16 @@ public class ActivityShortData {
 
     protected String activityType;
 
+    protected String calledProcessInstanceId;
+
+    public String getCalledProcessInstanceId() {
+        return calledProcessInstanceId;
+    }
+
+    public void setCalledProcessInstanceId(String calledProcessInstanceId) {
+        this.calledProcessInstanceId = calledProcessInstanceId;
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/io/openbpm/control/entity/filter/ProcessDefinitionFilter.java
+++ b/src/main/java/io/openbpm/control/entity/filter/ProcessDefinitionFilter.java
@@ -41,6 +41,10 @@ public class ProcessDefinitionFilter {
 
     protected Boolean latestVersionOnly = true;
 
+    protected String versionTag;
+
+    protected Integer version;
+
     public ProcessDefinitionState getState() {
         return state == null ? null : ProcessDefinitionState.fromId(state);
     }

--- a/src/main/java/io/openbpm/control/entity/filter/ProcessInstanceFilter.java
+++ b/src/main/java/io/openbpm/control/entity/filter/ProcessInstanceFilter.java
@@ -48,6 +48,8 @@ public class ProcessInstanceFilter {
 
     protected List<String> activeActivityIdIn;
 
+    protected List<String> processInstanceIds;
+
     public Boolean getUnfinished() {
         return unfinished;
     }

--- a/src/main/java/io/openbpm/control/service/processinstance/impl/ProcessInstanceServiceImpl.java
+++ b/src/main/java/io/openbpm/control/service/processinstance/impl/ProcessInstanceServiceImpl.java
@@ -18,6 +18,7 @@ import io.openbpm.control.service.processinstance.ProcessInstanceLoadContext;
 import io.openbpm.control.service.processinstance.ProcessInstanceService;
 import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 import org.camunda.bpm.engine.variable.VariableMap;
@@ -421,7 +422,7 @@ public class ProcessInstanceServiceImpl implements ProcessInstanceService {
 
     protected List<String> findRuntimeInstancesWithIncidents(List<ProcessInstance> processInstances) {
         Set<String> activeInstanceIds = processInstances.stream()
-                .map(processInstance -> processInstance.getId())
+                .map(Execution::getId)
                 .collect(Collectors.toSet());
         return loadInstancesWithIncidents(activeInstanceIds);
     }
@@ -430,7 +431,7 @@ public class ProcessInstanceServiceImpl implements ProcessInstanceService {
         List<ProcessInstance> instancesWithIncidents = remoteRuntimeService.createProcessInstanceQuery()
                 .withIncident()
                 .processInstanceIds(activeInstanceIds)
-                .list();
+                .listPage(0, activeInstanceIds.size());
 
         return instancesWithIncidents.stream().map(ProcessInstance::getId).toList();
     }

--- a/src/main/java/io/openbpm/control/uicomponent/viewer/handler/CallActivityOverlayClickHandler.java
+++ b/src/main/java/io/openbpm/control/uicomponent/viewer/handler/CallActivityOverlayClickHandler.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.uicomponent.viewer.handler;
+
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.RouterLink;
+import io.jmix.core.Messages;
+import io.jmix.core.Metadata;
+import io.jmix.flowui.DialogWindows;
+import io.jmix.flowui.Notifications;
+import io.jmix.flowui.ViewNavigators;
+import io.jmix.flowui.view.View;
+import io.openbpm.control.entity.filter.ProcessDefinitionFilter;
+import io.openbpm.control.entity.processdefinition.ProcessDefinitionData;
+import io.openbpm.control.entity.processinstance.ProcessInstanceData;
+import io.openbpm.control.service.processdefinition.ProcessDefinitionLoadContext;
+import io.openbpm.control.service.processdefinition.ProcessDefinitionService;
+import io.openbpm.control.view.processdefinition.ProcessDefinitionDetailView;
+import io.openbpm.control.view.processinstance.CalledProcessInstanceDataListView;
+import io.openbpm.control.view.processinstance.ProcessInstanceDetailView;
+import io.openbpm.uikit.component.bpmnviewer.model.CallActivityData;
+import lombok.AllArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static io.jmix.flowui.component.UiComponentUtils.getCurrentView;
+
+/**
+ * Handles {@link io.openbpm.uikit.component.bpmnviewer.event.CalledProcessOverlayClickEvent}
+ * and {@link io.openbpm.uikit.component.bpmnviewer.event.CalledProcessInstanceOverlayClickEvent} events.
+ */
+@AllArgsConstructor
+@Component("control_CallActivityOverlayClickHandler")
+public class CallActivityOverlayClickHandler {
+
+    protected final ProcessDefinitionService processDefinitionService;
+    protected final Metadata metadata;
+    protected final Notifications notifications;
+    protected final ViewNavigators viewNavigators;
+    protected final DialogWindows dialogWindows;
+    protected final Messages messages;
+
+    /**
+     * Opens {@link ProcessDefinitionDetailView} for the process called from the specified process and activity.
+     *
+     * @param parentProcess    parent process
+     * @param callActivityData the data from Call activity element from the parent process
+     * @param fromDialog       current view is open in dialog or not
+     */
+    public void handleProcessNavigation(ProcessDefinitionData parentProcess,
+                                        CallActivityData callActivityData,
+                                        boolean fromDialog) {
+        ProcessDefinitionData calledProcess = findCalledProcess(callActivityData, parentProcess);
+        if (calledProcess != null) {
+            View<?> currentView = getCurrentView();
+            if (fromDialog) {
+                RouterLink routerLink = new RouterLink(ProcessDefinitionDetailView.class, new RouteParameters("id", calledProcess.getId()));
+                currentView.getUI().ifPresent(ui -> ui.getPage().open(routerLink.getHref()));
+            } else {
+                viewNavigators.detailView(currentView, ProcessDefinitionData.class)
+                        .withViewClass(ProcessDefinitionDetailView.class)
+                        .withRouteParameters(new RouteParameters("id", calledProcess.getId()))
+                        .withBackwardNavigation(true)
+                        .navigate();
+            }
+        }
+    }
+
+    /**
+     * Handles a navigation to the specified called process instances. If only one instance is provided, then {@link ProcessInstanceDetailView} is opened.
+     * Otherwise, opens {@link CalledProcessInstanceDataListView}.
+     *
+     * @param calledProcessInstanceIds a list of process instances called from the other process instance
+     */
+    public void handleInstancesNavigation(List<String> calledProcessInstanceIds) {
+        if (CollectionUtils.size(calledProcessInstanceIds) == 1) {
+            viewNavigators.detailView(getCurrentView(), ProcessInstanceData.class)
+                    .withViewClass(ProcessInstanceDetailView.class)
+                    .withRouteParameters(new RouteParameters("id", calledProcessInstanceIds.getFirst()))
+                    .withBackwardNavigation(true)
+                    .navigate();
+        } else {
+            dialogWindows.view(getCurrentView(), CalledProcessInstanceDataListView.class)
+                    .withViewConfigurer(view -> view.setProcessInstanceIds(calledProcessInstanceIds))
+                    .open();
+        }
+    }
+
+    @Nullable
+    protected ProcessDefinitionData findCalledProcess(CallActivityData callActivityData, ProcessDefinitionData parentProcess) {
+        ProcessDefinitionFilter filter = createFilter(callActivityData, parentProcess);
+        if (filter == null) {
+            return null;
+        }
+
+        List<ProcessDefinitionData> calledProcesses = processDefinitionService.findAll(new ProcessDefinitionLoadContext()
+                .setFilter(filter));
+
+        if (CollectionUtils.isEmpty(calledProcesses)) {
+            notifications.create(messages.formatMessage("", "calledProcessNotFound.title", callActivityData.getCalledElement()),
+                            getAdditionalFilterMessage(callActivityData.getBinding(), filter))
+                    .withType(Notifications.Type.WARNING)
+                    .show();
+            return null;
+        }
+        return CollectionUtils.isNotEmpty(calledProcesses) ? calledProcesses.getFirst() : null;
+    }
+
+    protected String getAdditionalFilterMessage(@Nullable String binding, ProcessDefinitionFilter filter) {
+        String bindingName = StringUtils.defaultIfEmpty(binding, "latest");
+        String additionalParamMessage = switch (bindingName) {
+            case "version" -> messages.formatMessage("", "calledProcessNotFound.description.version",
+                    filter.getVersion());
+            case "versionTag" -> messages.formatMessage("", "calledProcessNotFound.description.versionTag",
+                    filter.getVersionTag());
+            case "deployment" -> messages.formatMessage("", "calledProcessNotFound.description.deployment",
+                    filter.getDeploymentId());
+            default -> "";
+        };
+
+        return String.join("\n", messages.formatMessage("", "calledProcessNotFound.description.binding",
+                bindingName), additionalParamMessage);
+    }
+
+    @Nullable
+    protected ProcessDefinitionFilter createFilter(CallActivityData callActivityData, ProcessDefinitionData parentProcess) {
+        String processKey = callActivityData.getCalledElement();
+        String binding = callActivityData.getBinding();
+
+        ProcessDefinitionFilter filter = metadata.create(ProcessDefinitionFilter.class);
+        filter.setLatestVersionOnly(false);
+        filter.setKey(processKey);
+
+        switch (binding) {
+            case "version" -> {
+                try {
+                    Integer version = Integer.parseInt(callActivityData.getVersion());
+                    filter.setVersion(version);
+                } catch (NumberFormatException e) {
+                    notifications.create(messages.formatMessage("", "calledProcessNotFound.title", processKey),
+                                    messages.formatMessage("", "calledProcessNotFound.description.invalidVersion", callActivityData.getVersion()))
+                            .withType(Notifications.Type.WARNING)
+                            .show();
+                    return null;
+                }
+            }
+            case "versionTag" -> filter.setVersionTag(callActivityData.getVersionTag());
+            case "deployment" -> filter.setDeploymentId(parentProcess.getDeploymentId());
+            case null, default -> filter.setLatestVersionOnly(true);
+        }
+
+        return filter;
+    }
+}

--- a/src/main/java/io/openbpm/control/util/QueryUtils.java
+++ b/src/main/java/io/openbpm/control/util/QueryUtils.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -45,6 +46,7 @@ public class QueryUtils {
             return;
         }
 
+        addIfNotNull(filter.getProcessInstanceIds(), instanceIds -> processInstanceQuery.processInstanceIds(new HashSet<>(instanceIds)));
         addIfStringNotEmpty(filter.getProcessDefinitionId(), processInstanceQuery::processDefinitionId);
         addIfStringNotEmpty(filter.getProcessDefinitionKey(), processInstanceQuery::processDefinitionKey);
         wrapAndAddStringIfNotEmpty(filter.getBusinessKeyLike(), processInstanceQuery::processInstanceBusinessKeyLike);
@@ -78,6 +80,7 @@ public class QueryUtils {
             return;
         }
 
+        addIfNotNull(filter.getProcessInstanceIds(), queryDto::processInstanceIds);
         addIfStringNotEmpty(filter.getProcessDefinitionId(), queryDto::processDefinitionId);
         addIfStringNotEmpty(filter.getProcessDefinitionKey(), queryDto::processDefinitionKey);
         addIfStringNotEmpty(filter.getProcessInstanceId(), queryDto::processInstanceId);
@@ -141,6 +144,8 @@ public class QueryUtils {
         wrapAndAddStringIfNotEmpty(filter.getNameLike(), processDefinitionQuery::processDefinitionNameLike);
 
         addIfStringNotEmpty(filter.getKey(), processDefinitionQuery::processDefinitionKey);
+        addIfStringNotEmpty(filter.getVersionTag(), processDefinitionQuery::versionTag);
+        addIfNotNull(filter.getVersion(), processDefinitionQuery::processDefinitionVersion);
 
         addCollectionIfNotEmpty(filter.getKeyIn(), processDefinitionQuery::processDefinitionKeyIn);
         addCollectionIfNotEmpty(filter.getIdIn(), processDefinitionQuery::processDefinitionIdIn);

--- a/src/main/java/io/openbpm/control/view/processdefinition/GeneralPanelFragment.java
+++ b/src/main/java/io/openbpm/control/view/processdefinition/GeneralPanelFragment.java
@@ -15,6 +15,7 @@ import com.vaadin.flow.theme.lumo.LumoUtility;
 import io.jmix.core.Messages;
 import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.Notifications;
+import io.jmix.flowui.UiEventPublisher;
 import io.jmix.flowui.ViewNavigators;
 import io.jmix.flowui.component.datetimepicker.TypedDateTimePicker;
 import io.jmix.flowui.component.formlayout.JmixFormLayout;
@@ -38,6 +39,7 @@ import io.openbpm.control.entity.processdefinition.ProcessDefinitionData;
 import io.openbpm.control.entity.processinstance.ProcessInstanceData;
 import io.openbpm.control.service.deployment.DeploymentService;
 import io.openbpm.control.view.deploymentdata.DeploymentDetailView;
+import io.openbpm.control.view.processdefinition.event.ReloadSelectedProcess;
 import io.openbpm.control.view.processinstancemigration.ProcessInstanceMigrationView;
 import io.openbpm.control.view.startprocess.StartProcessWithVariableView;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,6 +93,8 @@ public class GeneralPanelFragment extends Fragment<FlexLayout> {
     protected CopyComponentValueToClipboardAction copyIdAction;
     @ViewComponent
     protected CopyComponentValueToClipboardAction copyKeyAction;
+    @Autowired
+    protected UiEventPublisher uiEventPublisher;
 
     @Subscribe
     public void onReady(ReadyEvent event) {
@@ -100,7 +104,6 @@ public class GeneralPanelFragment extends Fragment<FlexLayout> {
     @Subscribe(target = Target.HOST_CONTROLLER)
     public void onHostBeforeShow(View.BeforeShowEvent event) {
         initActionButtons();
-        initDeploymentData();
 
         copyIdAction.setTarget(idField);
         copyKeyAction.setTarget(keyField);
@@ -244,11 +247,6 @@ public class GeneralPanelFragment extends Fragment<FlexLayout> {
 
 
     protected void reloadProcessDefinition() {
-        if (processDefinitionDataDc instanceof HasLoader container) {
-            DataLoader loader = container.getLoader();
-            if (loader != null) {
-                loader.load();
-            }
-        }
+        uiEventPublisher.publishEventForCurrentUI(new ReloadSelectedProcess(this));
     }
 }

--- a/src/main/java/io/openbpm/control/view/processdefinition/ProcessDefinitionDiagramView.java
+++ b/src/main/java/io/openbpm/control/view/processdefinition/ProcessDefinitionDiagramView.java
@@ -8,8 +8,10 @@ package io.openbpm.control.view.processdefinition;
 
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.jmix.flowui.component.UiComponentUtils;
 import io.openbpm.control.entity.processdefinition.ProcessDefinitionData;
 import io.openbpm.control.service.processdefinition.ProcessDefinitionService;
+import io.openbpm.control.uicomponent.viewer.handler.CallActivityOverlayClickHandler;
 import io.openbpm.uikit.fragment.bpmnviewer.BpmnViewerFragment;
 import io.openbpm.control.view.main.MainView;
 import io.jmix.flowui.model.InstanceContainer;
@@ -29,6 +31,8 @@ public class ProcessDefinitionDiagramView extends StandardView {
     protected BpmnViewerFragment viewerFragment;
     @ViewComponent
     protected InstanceContainer<ProcessDefinitionData> processDefinitionDc;
+    @Autowired
+    protected CallActivityOverlayClickHandler callActivityClickHandler;
 
     @SuppressWarnings("LombokSetterMayBeUsed")
     public void setProcessDefinition(ProcessDefinitionData processDefinitionId) {
@@ -47,6 +51,12 @@ public class ProcessDefinitionDiagramView extends StandardView {
 
         String bpmnXml = processDefinitionService.getBpmnXml(processDefinition.getProcessDefinitionId());
         viewerFragment.initViewer(bpmnXml);
+        viewerFragment.showCalledProcessOverlays();
+        viewerFragment.addCalledProcessOverlayClickListener(callActivityOverlayClickEvent -> {
+            callActivityClickHandler.handleProcessNavigation(processDefinitionDc.getItem(),
+                    callActivityOverlayClickEvent.getCallActivity(),
+                    UiComponentUtils.isComponentAttachedToDialog(this));
+        });
     }
 
 }

--- a/src/main/java/io/openbpm/control/view/processdefinition/event/ReloadSelectedProcess.java
+++ b/src/main/java/io/openbpm/control/view/processdefinition/event/ReloadSelectedProcess.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.processdefinition.event;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Event for reloading the selected process definition in {@link io.openbpm.control.view.processdefinition.ProcessDefinitionDetailView}
+ */
+public class ReloadSelectedProcess extends ApplicationEvent {
+    public ReloadSelectedProcess(Object source) {
+        super(source);
+    }
+}

--- a/src/main/java/io/openbpm/control/view/processinstance/CalledProcessInstanceDataListView.java
+++ b/src/main/java/io/openbpm/control/view/processinstance/CalledProcessInstanceDataListView.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Haulmont 2025. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.openbpm.control.view.processinstance;
+
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.RouterLink;
+import io.jmix.core.DataManager;
+import io.jmix.core.LoadContext;
+import io.jmix.core.Messages;
+import io.jmix.flowui.UiComponents;
+import io.jmix.flowui.ViewNavigators;
+import io.jmix.flowui.component.UiComponentUtils;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.view.DialogMode;
+import io.jmix.flowui.view.Install;
+import io.jmix.flowui.view.LookupComponent;
+import io.jmix.flowui.view.StandardListView;
+import io.jmix.flowui.view.Supply;
+import io.jmix.flowui.view.Target;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import io.openbpm.control.entity.filter.ProcessInstanceFilter;
+import io.openbpm.control.entity.processinstance.ProcessInstanceData;
+import io.openbpm.control.service.processinstance.ProcessInstanceLoadContext;
+import io.openbpm.control.service.processinstance.ProcessInstanceService;
+import io.openbpm.control.view.main.MainView;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static io.jmix.flowui.component.UiComponentUtils.getCurrentView;
+
+@Route(value = "called-process-instances", layout = MainView.class)
+@ViewController(id = "bpm_CalledProcessInstanceData.list")
+@ViewDescriptor(path = "called-process-instance-data-list-view.xml")
+@LookupComponent("processInstancesDataGrid")
+@DialogMode(minWidth = "65em", width = "70%")
+public class CalledProcessInstanceDataListView extends StandardListView<ProcessInstanceData> {
+
+    @Autowired
+    protected UiComponents uiComponents;
+    @Autowired
+    protected ProcessInstanceService processInstanceService;
+    @Autowired
+    protected DataManager dataManager;
+    @Autowired
+    protected Messages messages;
+    @Autowired
+    protected ViewNavigators viewNavigators;
+
+    protected List<String> processInstanceIds;
+
+    public void setProcessInstanceIds(List<String> processInstanceIds) {
+        this.processInstanceIds = processInstanceIds;
+    }
+
+    @Install(to = "processInstancesDl", target = Target.DATA_LOADER)
+    protected List<ProcessInstanceData> processInstancesDlLoadDelegate(LoadContext<ProcessInstanceData> loadContext) {
+        if (CollectionUtils.isEmpty(processInstanceIds)) {
+            return List.of();
+        }
+        ProcessInstanceFilter filter = dataManager.create(ProcessInstanceFilter.class);
+        filter.setProcessInstanceIds(processInstanceIds);
+
+        ProcessInstanceLoadContext context = new ProcessInstanceLoadContext()
+                .setFirstResult(0)
+                .setMaxResults(processInstanceIds.size())
+                .setFilter(filter);
+
+        return processInstanceService.findAllHistoricInstances(context);
+    }
+
+    @Supply(to = "processInstancesDataGrid.processDefinitionId", subject = "renderer")
+    protected Renderer<ProcessInstanceData> processInstancesDataGridProcessDefinitionIdRenderer() {
+        return new TextRenderer<>(item -> item.getProcessDefinitionVersion() == null ? item.getProcessDefinitionId() :
+                messages.formatMessage("", "common.processDefinitionKeyAndVersion", item.getProcessDefinitionKey(),
+                        item.getProcessDefinitionVersion()));
+    }
+
+
+    @Supply(to = "processInstancesDataGrid.actions", subject = "renderer")
+    protected Renderer<ProcessInstanceData> processInstancesDataGridActionsRenderer() {
+        return new ComponentRenderer<>(item -> {
+            JmixButton viewButton = uiComponents.create(JmixButton.class);
+            viewButton.setText(messages.getMessage("actions.View"));
+            viewButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+            viewButton.setIcon(VaadinIcon.EYE.create());
+            viewButton.addClickListener(event -> {
+                if (UiComponentUtils.isComponentAttachedToDialog(this)) {
+                    RouterLink routerLink = new RouterLink(ProcessInstanceDetailView.class,
+                            new RouteParameters("id", item.getId()));
+                    getUI().ifPresent(ui -> ui.getPage().open(routerLink.getHref()));
+                } else {
+                    openProcessInstanceDetailView(item);
+                }
+            });
+
+            return viewButton;
+        });
+    }
+
+    protected void openProcessInstanceDetailView(ProcessInstanceData item) {
+        viewNavigators.detailView(getCurrentView(), ProcessInstanceData.class)
+                .withViewClass(ProcessInstanceDetailView.class)
+                .withRouteParameters(new RouteParameters("id", item.getId()))
+                .withBackwardNavigation(true)
+                .navigate();
+    }
+}

--- a/src/main/resources/io/openbpm/control/messages_de.properties
+++ b/src/main/resources/io/openbpm/control/messages_de.properties
@@ -22,6 +22,12 @@ viewer.openDecisionInstanceOverlay.tooltipMessage=Entscheidungsinstanz mit ID ö
 
 thousandsFormat=#.#
 
+calledProcessNotFound.title=Aufgerufener Prozess '%s' nicht gefunden
+calledProcessNotFound.description.binding=Bindung: %s
+calledProcessNotFound.description.deployment=Einsatz: %s
+calledProcessNotFound.description.invalidVersion=Version (%s) ist keine Zahl
+calledProcessNotFound.description.version=Version: %s
+calledProcessNotFound.description.versionTag=Versions-Tag: %s
 common.processDefinitionKeyAndVersion=%s (Version %s)
 
 engineAvailable=Erfolgreich mit '%s' verbunden
@@ -552,6 +558,7 @@ io.openbpm.control.view.processinstance.generalpanel/processInstanceTerminated=P
 
 io.openbpm.control.view.processinstance/processKey=Prozess
 io.openbpm.control.view.processinstance/bulkTerminateProcessesStarted=Beenden der Prozessinstanzen gestartet
+io.openbpm.control.view.processinstance/calledProcessInstanceDataListView.title=Aufgerufene Prozessinstanzen
 
 io.openbpm.control.view.processinstance.runtime/variablesTabCaption=Variablen (%s)
 io.openbpm.control.view.processinstance.runtime/tasksTabCaption=Benutzeraufgaben (%s)
@@ -644,6 +651,7 @@ io.openbpm.control.entity.activity/ActivityShortData=Aktivität
 io.openbpm.control.entity.activity/ActivityShortData.activityId=Aktivitäts-ID
 io.openbpm.control.entity.activity/ActivityShortData.activityName=Aktivitätsname
 io.openbpm.control.entity.activity/ActivityShortData.activityType=Aktivitätstyp
+io.openbpm.control.entity.activity/ActivityShortData.calledProcessInstanceId=Called process instance id
 io.openbpm.control.entity.activity/ActivityShortData.id=ID
 io.openbpm.control.entity.activity/ActivityShortData.internalId=Interne ID
 io.openbpm.control.entity.activity/HistoricActivityInstanceData=Historische Aktivitätsinstanzdaten

--- a/src/main/resources/io/openbpm/control/messages_en.properties
+++ b/src/main/resources/io/openbpm/control/messages_en.properties
@@ -22,6 +22,12 @@ viewer.openDecisionInstanceOverlay.tooltipMessage=Open decision instance with id
 
 thousandsFormat=#.#
 
+calledProcessNotFound.title=Called process '%s' not found
+calledProcessNotFound.description.binding=Binding: %s
+calledProcessNotFound.description.deployment=Deployment: %s
+calledProcessNotFound.description.invalidVersion=Version (%s) is not a number
+calledProcessNotFound.description.version=Version: %s
+calledProcessNotFound.description.versionTag=Version tag: %s
 common.processDefinitionKeyAndVersion=%s (ver. %s)
 
 engineAvailable=Successfully connected to '%s'
@@ -564,6 +570,7 @@ io.openbpm.control.view.processinstance.generalpanel/processInstanceTerminated=P
 
 io.openbpm.control.view.processinstance/processKey=Process
 io.openbpm.control.view.processinstance/bulkTerminateProcessesStarted=Terminating process instances started
+io.openbpm.control.view.processinstance/calledProcessInstanceDataListView.title=Called process instances
 
 io.openbpm.control.view.processinstance.runtime/variablesTabCaption=Variables (%s)
 io.openbpm.control.view.processinstance.runtime/tasksTabCaption=User tasks (%s)
@@ -658,6 +665,7 @@ io.openbpm.control.entity.activity/ActivityShortData=Activity
 io.openbpm.control.entity.activity/ActivityShortData.activityId=Activity Id
 io.openbpm.control.entity.activity/ActivityShortData.activityName=Activity name
 io.openbpm.control.entity.activity/ActivityShortData.activityType=Activity type
+io.openbpm.control.entity.activity/ActivityShortData.calledProcessInstanceId=Called process instance id
 io.openbpm.control.entity.activity/ActivityShortData.id=Id
 io.openbpm.control.entity.activity/ActivityShortData.internalId=Internal Id
 io.openbpm.control.entity.activity/HistoricActivityInstanceData=Historic activity instance data

--- a/src/main/resources/io/openbpm/control/messages_es.properties
+++ b/src/main/resources/io/openbpm/control/messages_es.properties
@@ -22,6 +22,12 @@ viewer.openDecisionInstanceOverlay.tooltipMessage=Abrir instancia de decisión c
 
 thousandsFormat=#.#
 
+calledProcessNotFound.title=No se encontró el proceso llamado '%s'
+calledProcessNotFound.description.binding=Vinculante: %s
+calledProcessNotFound.description.deployment=Despliegue: %s
+calledProcessNotFound.description.invalidVersion=La versión (%s) no es un número
+calledProcessNotFound.description.version=Versión: %s
+calledProcessNotFound.description.versionTag=Etiqueta de versión: %s
 common.processDefinitionKeyAndVersion=%s (ver. %s)
 
 engineAvailable=Conectado exitosamente a '%s'
@@ -555,6 +561,7 @@ io.openbpm.control.view.processinstance.generalpanel/processInstanceTerminated=I
 
 io.openbpm.control.view.processinstance/processKey=Proceso
 io.openbpm.control.view.processinstance/bulkTerminateProcessesStarted=Inicio de terminación de instancias de proceso
+io.openbpm.control.view.processinstance/calledProcessInstanceDataListView.title=Instancias de proceso llamadas
 
 io.openbpm.control.view.processinstance.runtime/variablesTabCaption=Variables (%s)
 io.openbpm.control.view.processinstance.runtime/tasksTabCaption=Tareas de usuario (%s)
@@ -647,6 +654,7 @@ io.openbpm.control.entity.activity/ActivityShortData=Actividad
 io.openbpm.control.entity.activity/ActivityShortData.activityId=Id de actividad
 io.openbpm.control.entity.activity/ActivityShortData.activityName=Nombre de la actividad
 io.openbpm.control.entity.activity/ActivityShortData.activityType=Tipo de actividad
+io.openbpm.control.entity.activity/ActivityShortData.calledProcessInstanceId=Called process instance id
 io.openbpm.control.entity.activity/ActivityShortData.id=Id
 io.openbpm.control.entity.activity/ActivityShortData.internalId=Id interno
 io.openbpm.control.entity.activity/HistoricActivityInstanceData=Datos de instancia de actividad histórica

--- a/src/main/resources/io/openbpm/control/messages_ru.properties
+++ b/src/main/resources/io/openbpm/control/messages_ru.properties
@@ -22,6 +22,12 @@ viewer.openDecisionInstanceOverlay.tooltipMessage=Открыть экземпл�
 
 thousandsFormat=#.#
 
+calledProcessNotFound.title=Вызываемый процесс '%s' не найден
+calledProcessNotFound.description.binding=Связывание: %s
+calledProcessNotFound.description.deployment=Развертывание: %s
+calledProcessNotFound.description.invalidVersion=Версия (%s) не является числом
+calledProcessNotFound.description.version=Версия: %s
+calledProcessNotFound.description.versionTag=Тег версии: %s
 common.processDefinitionKeyAndVersion=%s (вер. %s)
 
 engineAvailable=Успешно подключено к '%s'
@@ -562,6 +568,7 @@ io.openbpm.control.view.processinstance/processKey=Процесс
 
 io.openbpm.control.view.processinstance.generalpanel/processInstanceTerminated=Экземпляр процесса завершен
 io.openbpm.control.view.processinstance/bulkTerminateProcessesStarted=Завершение экземпляров процессов запущено
+io.openbpm.control.view.processinstance/calledProcessInstanceDataListView.title=Вызываемые экземпляры процесса
 
 io.openbpm.control.view.processinstance.runtime/variablesTabCaption=Переменные (%s)
 io.openbpm.control.view.processinstance.runtime/tasksTabCaption=Пользовательские задачи (%s)
@@ -658,6 +665,7 @@ io.openbpm.control.entity.activity/ActivityShortData=Активность
 io.openbpm.control.entity.activity/ActivityShortData.activityId=Id активности
 io.openbpm.control.entity.activity/ActivityShortData.activityName=Имя активности
 io.openbpm.control.entity.activity/ActivityShortData.activityType=Тип активности
+io.openbpm.control.entity.activity/ActivityShortData.calledProcessInstanceId=Called process instance id
 io.openbpm.control.entity.activity/ActivityShortData.id=Id
 io.openbpm.control.entity.activity/ActivityShortData.internalId=Internal Id
 io.openbpm.control.entity.activity/HistoricActivityInstanceData=Historic activity instance data

--- a/src/main/resources/io/openbpm/control/view/processdefinition/process-definition-detail-view.xml
+++ b/src/main/resources/io/openbpm/control/view/processdefinition/process-definition-detail-view.xml
@@ -19,9 +19,6 @@
             <fetchPlan extends="_base"/>
         </instance>
     </data>
-    <facets>
-        <dataLoadCoordinator auto="true"/>
-    </facets>
     <actions>
         <action id="closeAction" type="detail_close" text="msg:///actions.Close"/>
     </actions>

--- a/src/main/resources/io/openbpm/control/view/processinstance/called-process-instance-data-list-view.xml
+++ b/src/main/resources/io/openbpm/control/view/processinstance/called-process-instance-data-list-view.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2025. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view"
+      title="msg://calledProcessInstanceDataListView.title"
+      focusComponent="processInstancesDataGrid">
+    <data>
+        <collection id="processInstancesDc"
+                    class="io.openbpm.control.entity.processinstance.ProcessInstanceData">
+            <loader id="processInstancesDl" readOnly="true"/>
+        </collection>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+        <urlQueryParameters>
+            <pagination component="pagination"/>
+        </urlQueryParameters>
+    </facets>
+    <actions>
+        <action id="closeAction" type="view_close" text="msg:///actions.Close"/>
+    </actions>
+    <layout>
+        <hbox id="buttonsPanel" classNames="buttons-panel">
+            <simplePagination id="pagination" dataLoader="processInstancesDl"/>
+        </hbox>
+        <dataGrid id="processInstancesDataGrid"
+                  width="100%"
+                  minHeight="20em"
+                  dataContainer="processInstancesDc"
+                  columnReorderingAllowed="true">
+            <actions>
+            </actions>
+            <columns resizable="true">
+                <column property="id">
+                    <fragmentRenderer class="io.openbpm.control.view.processinstance.column.instanceid.InstanceIdColumnFragment"/>
+                </column>
+                <column property="processDefinitionId" resizable="true" header="msg://processKey" flexGrow="2"
+                        autoWidth="true"/>
+                <column property="businessKey"/>
+                <column property="startTime"/>
+                <column property="endTime"/>
+                <column property="state">
+                    <fragmentRenderer class="io.openbpm.control.view.processinstance.column.state.ProcessInstanceStateColumnFragment"/>
+                </column>
+                <column key="actions" sortable="false" autoWidth="true" flexGrow="0"/>
+            </columns>
+        </dataGrid>
+        <hbox id="lookupActions">
+            <button id="closeButton" action="closeAction"/>
+        </hbox>
+    </layout>
+</view>


### PR DESCRIPTION
1. Add overlays for Call activity diagram element in ProcessDefinitionDetailView and ProcessDefinitionDiagramView to navigate to the called process. If an overlay clicked then ProcessDefinitionDetailView is opened for the called process.

2. Add overlays for Call activity diagram element in ProcessInstanceDetailView to navigate to the called process instance(s). If only one called process instance exists, then ProcessInstanceDetailView for called instance is opened. Otherwise, CalledProcessInstanceDataListView with list of called instances is opened.

3. Refactor ProcessDefinitionDetailView for correct navigation between process and called process.