### PR TITLE
#JBPMP-522 Unexpected error is thrown if try to view stacktrace for h…

### DIFF
--- a/src/main/java/io/openbpm/control/service/job/JobService.java
+++ b/src/main/java/io/openbpm/control/service/job/JobService.java
@@ -73,4 +73,13 @@ public interface JobService {
      * @return error details
      */
     String getHistoryErrorDetails(String jobId);
+
+
+    /**
+     * Loads from the engine history the job with the specified identifier.
+     *
+     * @param jobId a job identifier
+     * @return boolean
+     */
+    boolean isHistoryJobLogPresent(String jobId);
 }

--- a/src/main/java/io/openbpm/control/service/job/impl/JobServiceImpl.java
+++ b/src/main/java/io/openbpm/control/service/job/impl/JobServiceImpl.java
@@ -155,7 +155,7 @@ public class JobServiceImpl implements JobService {
             ResponseEntity<HistoricJobLogDto> jobLogResponse = historyApiClient.getHistoricJobLog(jobId);
             return jobLogResponse.getStatusCode().is2xxSuccessful() && jobLogResponse.getBody() != null;
         } catch (FeignException e) {
-            System.err.println("Error checking job log presence for jobId: " + jobId + ", error: " + e.getMessage());
+            log.error("Error checking job log presence for jobId: {}, error: ", jobId, e);
             return false;
         }
     }
@@ -218,7 +218,7 @@ public class JobServiceImpl implements JobService {
             }
             return "";
         } catch (Exception e) {
-            System.err.println("Fallback request failed for history jobId: " + jobId + ", error: " + e.getMessage());
+            log.error("Fallback request failed for history jobId: {}, error: {}", jobId, e.getMessage(), e);
             return "";
         }
     }

--- a/src/main/java/io/openbpm/control/service/job/impl/JobServiceImpl.java
+++ b/src/main/java/io/openbpm/control/service/job/impl/JobServiceImpl.java
@@ -154,7 +154,8 @@ public class JobServiceImpl implements JobService {
         try {
             ResponseEntity<HistoricJobLogDto> jobLogResponse = historyApiClient.getHistoricJobLog(jobId);
             return jobLogResponse.getStatusCode().is2xxSuccessful() && jobLogResponse.getBody() != null;
-        } catch (FeignException.NotFound e) {
+        } catch (FeignException e) {
+            System.err.println("Error checking job log presence for jobId: " + jobId + ", error: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/java/io/openbpm/control/service/job/impl/JobServiceImpl.java
+++ b/src/main/java/io/openbpm/control/service/job/impl/JobServiceImpl.java
@@ -6,6 +6,7 @@
 package io.openbpm.control.service.job.impl;
 
 import com.google.common.base.Strings;
+import feign.FeignException;
 import io.jmix.core.Sort;
 import io.openbpm.control.entity.filter.JobFilter;
 import io.openbpm.control.entity.job.JobData;
@@ -19,11 +20,14 @@ import org.camunda.community.rest.client.api.HistoryApiClient;
 import org.camunda.community.rest.client.api.JobApiClient;
 import org.camunda.community.rest.client.api.JobDefinitionApiClient;
 import org.camunda.community.rest.client.model.*;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static io.openbpm.control.util.EngineRestUtils.getCountResult;
@@ -35,6 +39,15 @@ public class JobServiceImpl implements JobService {
     protected final JobApiClient jobApiClient;
     protected final JobDefinitionApiClient jobDefinitionApiClient;
     protected final HistoryApiClient historyApiClient;
+
+    @Value("${feign.client.config.job.url:http://localhost:8080/engine-rest}")
+    protected String engineRestUrl;
+
+    @Value("${camunda.username:admin}")
+    protected String camundaUsername;
+
+    @Value("${camunda.password:admin}")
+    protected String camundaPassword;
 
     public JobServiceImpl(JobMapper jobMapper,
                           JobApiClient jobApiClient,
@@ -125,11 +138,25 @@ public class JobServiceImpl implements JobService {
 
     @Override
     public String getHistoryErrorDetails(String jobId) {
-        ResponseEntity<String> response = historyApiClient.getStacktraceHistoricJobLog(jobId);
-        if (response.getStatusCode().is2xxSuccessful()) {
-            return Strings.nullToEmpty(response.getBody());
+        try {
+            ResponseEntity<String> response = historyApiClient.getStacktraceHistoricJobLog(jobId);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return Strings.nullToEmpty(response.getBody());
+            }
+            return "";
+        } catch (FeignException.NotAcceptable e) {
+            return fallbackGetHistoryStacktrace(jobId);
         }
-        return "";
+    }
+
+    @Override
+    public boolean isHistoryJobLogPresent(String jobId) {
+        try {
+            ResponseEntity<HistoricJobLogDto> jobLogResponse = historyApiClient.getHistoricJobLog(jobId);
+            return jobLogResponse.getStatusCode().is2xxSuccessful() && jobLogResponse.getBody() != null;
+        } catch (FeignException.NotFound e) {
+            return false;
+        }
     }
 
     protected JobQueryDto createJobQueryDto(JobFilter filter) {
@@ -170,5 +197,28 @@ public class JobServiceImpl implements JobService {
         }
 
         return jobQueryDtoSortingInners;
+    }
+
+    protected String fallbackGetHistoryStacktrace(String jobId) {
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setAccept(Collections.singletonList(MediaType.TEXT_PLAIN));
+            headers.setBasicAuth(camundaUsername, camundaPassword);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    engineRestUrl + "/history/job-log/" + jobId + "/stacktrace",
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return Strings.nullToEmpty(response.getBody());
+            }
+            return "";
+        } catch (Exception e) {
+            System.err.println("Fallback request failed for history jobId: " + jobId + ", error: " + e.getMessage());
+            return "";
+        }
     }
 }

--- a/src/main/java/io/openbpm/control/view/historicincidentdata/HistoricIncidentDataDetailView.java
+++ b/src/main/java/io/openbpm/control/view/historicincidentdata/HistoricIncidentDataDetailView.java
@@ -70,13 +70,14 @@ public class HistoricIncidentDataDetailView extends StandardDetailView<HistoricI
 
     protected void initIncidentTypeRelatedFields() {
         boolean notEmptyPayload = getEditedEntity().getConfiguration() != null;
+        boolean historyJobLogPresent = jobService.isHistoryJobLogPresent(getEditedEntity().getConfiguration());
 
         if (getEditedEntity().isExternalTaskFailed()) {
-            viewStacktraceBtn.setVisible(notEmptyPayload && jobService.isHistoryJobLogPresent(getEditedEntity().getConfiguration()));
+            viewStacktraceBtn.setVisible(notEmptyPayload && historyJobLogPresent);
             configurationField.setLabel(messages.getMessage("io.openbpm.control.view.incidentdata/externalTaskIdLabel"));
         } else if (getEditedEntity().isJobFailed()) {
             configurationField.setLabel(messages.getMessage("io.openbpm.control.view.incidentdata/jobIdLabel"));
-            viewStacktraceBtn.setVisible(notEmptyPayload && jobService.isHistoryJobLogPresent(getEditedEntity().getConfiguration()));
+            viewStacktraceBtn.setVisible(notEmptyPayload && historyJobLogPresent);
         } else {
             viewStacktraceBtn.setVisible(false);
         }

--- a/src/main/java/io/openbpm/control/view/historicincidentdata/HistoricIncidentDataDetailView.java
+++ b/src/main/java/io/openbpm/control/view/historicincidentdata/HistoricIncidentDataDetailView.java
@@ -16,13 +16,12 @@ import io.jmix.flowui.kit.component.button.JmixButton;
 import io.jmix.flowui.view.*;
 import io.openbpm.control.entity.incident.HistoricIncidentData;
 import io.openbpm.control.service.incident.IncidentService;
+import io.openbpm.control.service.job.impl.JobServiceImpl;
 import io.openbpm.control.view.externaltask.ExternalTaskErrorDetailsView;
 import io.openbpm.control.view.job.JobErrorDetailsView;
 import io.openbpm.control.view.main.MainView;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Objects;
 
 @Route(value = "historic-incidents/:id", layout = MainView.class)
 @ViewController("HistoricIncidentData.detail")
@@ -45,6 +44,8 @@ public class HistoricIncidentDataDetailView extends StandardDetailView<HistoricI
     protected TypedTextField<Object> rootCauseIncidentIdField;
     @Autowired
     protected DialogWindows dialogWindows;
+    @Autowired
+    protected JobServiceImpl jobService;
 
     @Subscribe
     public void onInit(final InitEvent event) {
@@ -71,11 +72,11 @@ public class HistoricIncidentDataDetailView extends StandardDetailView<HistoricI
         boolean notEmptyPayload = getEditedEntity().getConfiguration() != null;
 
         if (getEditedEntity().isExternalTaskFailed()) {
-            viewStacktraceBtn.setVisible(notEmptyPayload);
+            viewStacktraceBtn.setVisible(notEmptyPayload && jobService.isHistoryJobLogPresent(getEditedEntity().getConfiguration()));
             configurationField.setLabel(messages.getMessage("io.openbpm.control.view.incidentdata/externalTaskIdLabel"));
         } else if (getEditedEntity().isJobFailed()) {
             configurationField.setLabel(messages.getMessage("io.openbpm.control.view.incidentdata/jobIdLabel"));
-            viewStacktraceBtn.setVisible(notEmptyPayload);
+            viewStacktraceBtn.setVisible(notEmptyPayload && jobService.isHistoryJobLogPresent(getEditedEntity().getConfiguration()));
         } else {
             viewStacktraceBtn.setVisible(false);
         }


### PR DESCRIPTION
…istoric incident

Fixed 406 error for historic incident stacktrace
Added new logic, which hides viewStacktrace button when it's not possible to find the only log for historic job or external task