### PR TITLE
Blocking Control interface #113

### DIFF
--- a/src/main/frontend/themes/flowset-control/flowset-control.css
+++ b/src/main/frontend/themes/flowset-control/flowset-control.css
@@ -53,6 +53,11 @@ html {
     overflow: hidden;
 }
 
+.empty-grid-icon {
+    width: 2em;
+    height: 2em;
+}
+
 vaadin-grid::part(multiline-text-cell) {
     white-space: pre-wrap;
 }

--- a/src/main/java/io/flowset/control/configuration/UiComponentRegistrationConfiguration.java
+++ b/src/main/java/io/flowset/control/configuration/UiComponentRegistrationConfiguration.java
@@ -5,11 +5,13 @@
 
 package io.flowset.control.configuration;
 
+import io.flowset.control.uicomponent.grid.ControlDataGridLoader;
 import io.flowset.control.uicomponent.menu.ControlListMenu;
 import io.flowset.control.uicomponent.menu.ControlListMenuLoader;
 import io.flowset.control.uicomponent.spinner.SpinnerLoader;
 import io.flowset.control.uicomponent.treedatagrid.NoClickTreeDataGridLoader;
 import io.flowset.control.uicomponent.treedatagrid.NoClickTreeGrid;
+import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.sys.registration.ComponentRegistration;
 import io.jmix.flowui.sys.registration.ComponentRegistrationBuilder;
 import org.springframework.context.annotation.Bean;
@@ -40,4 +42,11 @@ public class UiComponentRegistrationConfiguration {
                 .build();
     }
 
+    @Bean
+    public ComponentRegistration controlDataGrid() {
+        return ComponentRegistrationBuilder
+                .create(DataGrid.class)
+                .withComponentLoader("dataGrid", ControlDataGridLoader.class)
+                .build();
+    }
 }

--- a/src/main/java/io/flowset/control/exception/ViewEngineConnectionFailedException.java
+++ b/src/main/java/io/flowset/control/exception/ViewEngineConnectionFailedException.java
@@ -1,0 +1,33 @@
+package io.flowset.control.exception;
+
+import io.jmix.flowui.view.View;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * An exception occurs when loading data from the BPM engine in a view (for example, in a data loader delegate) due to a connection error.
+ */
+@Getter
+@Setter
+public class ViewEngineConnectionFailedException extends RuntimeException {
+    private View<?> source;
+
+    public ViewEngineConnectionFailedException(View<?> source) {
+        this.source = source;
+    }
+
+    public ViewEngineConnectionFailedException(Throwable cause, View<?> source) {
+        super(cause);
+        this.source = source;
+    }
+
+    public ViewEngineConnectionFailedException(String message, View<?> source) {
+        super(message);
+        this.source = source;
+    }
+
+    public ViewEngineConnectionFailedException(String message, Throwable cause, View<?> source) {
+        super(message, cause);
+        this.source = source;
+    }
+}

--- a/src/main/java/io/flowset/control/handler/EngineConnectionFailedExceptionHandler.java
+++ b/src/main/java/io/flowset/control/handler/EngineConnectionFailedExceptionHandler.java
@@ -1,0 +1,112 @@
+package io.flowset.control.handler;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.entity.engine.BpmEngine;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.exception.ViewEngineConnectionFailedException;
+import io.flowset.control.service.engine.EngineService;
+import io.jmix.core.Messages;
+import io.jmix.flowui.Dialogs;
+import io.jmix.flowui.Notifications;
+import io.jmix.flowui.UiComponents;
+import io.jmix.flowui.UiProperties;
+import io.jmix.flowui.action.DialogAction;
+import io.jmix.flowui.exception.AbstractUiExceptionHandler;
+import io.jmix.flowui.kit.action.BaseAction;
+import io.jmix.flowui.view.navigation.ViewNavigationSupport;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * UI exception handler for {@link ViewEngineConnectionFailedException} and {@link EngineConnectionFailedException} exceptions.
+ */
+@Component
+public class EngineConnectionFailedExceptionHandler extends AbstractUiExceptionHandler {
+
+    protected final Notifications notifications;
+    protected final ViewNavigationSupport viewNavigationSupport;
+    protected final UiProperties uiProperties;
+    protected final Dialogs dialogs;
+    protected final EngineService engineService;
+    protected final UiComponents uiComponents;
+    protected final Messages messages;
+
+    public EngineConnectionFailedExceptionHandler(Notifications notifications,
+                                                  ViewNavigationSupport viewNavigationSupport,
+                                                  UiProperties uiProperties, Dialogs dialogs,
+                                                  EngineService engineService, UiComponents uiComponents,
+                                                  Messages messages) {
+        super(ViewEngineConnectionFailedException.class.getName(), EngineConnectionFailedException.class.getName());
+        this.notifications = notifications;
+        this.viewNavigationSupport = viewNavigationSupport;
+        this.uiProperties = uiProperties;
+        this.dialogs = dialogs;
+        this.engineService = engineService;
+        this.uiComponents = uiComponents;
+        this.messages = messages;
+    }
+
+
+    @Override
+    protected void doHandle(@NonNull String className, @NonNull String message, @Nullable Throwable throwable) {
+        if (throwable instanceof ViewEngineConnectionFailedException) {
+            dialogs.createOptionDialog()
+                    .withHeader(messages.getMessage(getClass(), "exceptionDialog.engineNotAvailable.header"))
+                    .withContent(createContent())
+                    .withActions(new BaseAction("retry")
+                                    .withText(messages.getMessage("actions.Retry"))
+                                    .withIcon(VaadinIcon.REFRESH.create())
+                                    .withHandler(actionPerformedEvent -> {
+                                        UI.getCurrent().getPage().reload();
+                                    }),
+                            new DialogAction(DialogAction.Type.CLOSE)
+                                    .withIcon(VaadinIcon.BAN.create())
+                                    .withHandler(actionPerformedEvent -> {
+                                        viewNavigationSupport.navigate(uiProperties.getMainViewId());
+                                    }))
+                    .open();
+        } else if (throwable instanceof EngineConnectionFailedException) {
+            notifications.create(messages.getMessage(getClass(), "exceptionDialog.engineNotAvailable.header"),
+                            getErrorText())
+                    .withType(Notifications.Type.ERROR)
+                    .show();
+        }
+
+    }
+
+    protected HorizontalLayout createContent() {
+        HorizontalLayout horizontalLayout = uiComponents.create(HorizontalLayout.class);
+        horizontalLayout.setAlignItems(FlexComponent.Alignment.CENTER);
+        horizontalLayout.addClassNames(LumoUtility.Border.ALL, LumoUtility.BorderRadius.LARGE,
+                LumoUtility.BorderColor.ERROR, LumoUtility.Background.ERROR_10, LumoUtility.Padding.SMALL);
+
+        Icon warningIcon = VaadinIcon.WARNING.create();
+        warningIcon.setSize("1.25em");
+        warningIcon.addClassNames(LumoUtility.TextColor.ERROR);
+
+        String text = getErrorText();
+        Span description = new Span(text);
+        description.addClassNames(LumoUtility.TextColor.ERROR, LumoUtility.Whitespace.PRE, LumoUtility.FontSize.SMALL);
+
+        horizontalLayout.add(warningIcon, description);
+        return horizontalLayout;
+    }
+
+    protected String getErrorText() {
+        BpmEngine selectedEngine = engineService.getSelectedEngine();
+        String text;
+        if (selectedEngine != null) {
+            text = messages.formatMessage(getClass(), "exceptionDialog.engineNotAvailable.engineDescription", selectedEngine.getBaseUrl());
+        } else {
+            text = messages.getMessage(getClass(), "exceptionDialog.engineNotAvailable.defaultDescription");
+        }
+        return text;
+    }
+}

--- a/src/main/java/io/flowset/control/service/activity/impl/ActivityServiceImpl.java
+++ b/src/main/java/io/flowset/control/service/activity/impl/ActivityServiceImpl.java
@@ -34,11 +34,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
-import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.flowset.control.util.EngineRestUtils.getCountResult;
+import static io.flowset.control.util.ExceptionUtils.isConnectionError;
 
 @Service("control_ActivityService")
 @Slf4j
@@ -186,7 +186,7 @@ public class ActivityServiceImpl implements ActivityService {
                 return null;
             }
 
-            if (rootCause instanceof ConnectException) {
+            if (isConnectionError(rootCause)) {
                 log.error("Unable load process definition activity statistics by id '{}' because of connection error: ", processDefinitionId, e);
                 return null;
             }

--- a/src/main/java/io/flowset/control/service/decisiondefinition/impl/DecisionDefinitionServiceImpl.java
+++ b/src/main/java/io/flowset/control/service/decisiondefinition/impl/DecisionDefinitionServiceImpl.java
@@ -2,6 +2,7 @@ package io.flowset.control.service.decisiondefinition.impl;
 
 import feign.FeignException;
 import feign.utils.ExceptionUtils;
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.jmix.core.Sort;
 import io.flowset.control.entity.decisiondefinition.DecisionDefinitionData;
 import io.flowset.control.entity.filter.DecisionDefinitionFilter;
@@ -20,9 +21,9 @@ import org.camunda.community.rest.impl.RemoteRepositoryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.net.ConnectException;
 import java.util.List;
 
+import static io.flowset.control.util.ExceptionUtils.isConnectionError;
 import static io.flowset.control.util.QueryUtils.*;
 
 @Service("control_DecisionDefinitionService")
@@ -100,9 +101,9 @@ public class DecisionDefinitionServiceImpl implements DecisionDefinitionService 
                 log.warn("Unable to load decision definitions because BPM engine not selected");
                 return List.of();
             }
-            if (rootCause instanceof ConnectException) {
+            if (isConnectionError(rootCause)) {
                 log.error("Unable to load decision definitions because of connection error: ", e);
-                return List.of();
+                throw new EngineConnectionFailedException(e.getMessage(), -1, e.getMessage());
             }
             throw e;
         }
@@ -128,10 +129,10 @@ public class DecisionDefinitionServiceImpl implements DecisionDefinitionService 
                         decisionDefinitionId);
                 return null;
             }
-            if (rootCause instanceof ConnectException) {
+            if (isConnectionError(rootCause)) {
                 log.error("Unable load decision definition by id '{}' because of connection error: ",
                         decisionDefinitionId, e);
-                return null;
+                throw new EngineConnectionFailedException(e.getMessage(), -1, e.getMessage());
             }
             throw e;
         }
@@ -154,7 +155,7 @@ public class DecisionDefinitionServiceImpl implements DecisionDefinitionService 
                         decisionDefinitionId);
                 return null;
             }
-            if (rootCause instanceof ConnectException) {
+            if (isConnectionError(rootCause)) {
                 log.error("Unable load decision definition XML by id '{}' because of connection error: ",
                         decisionDefinitionId, e);
                 return null;

--- a/src/main/java/io/flowset/control/service/decisioninstance/impl/DecisionInstanceServiceImpl.java
+++ b/src/main/java/io/flowset/control/service/decisioninstance/impl/DecisionInstanceServiceImpl.java
@@ -16,9 +16,9 @@ import org.camunda.community.rest.client.api.HistoryApiClient;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
-import java.net.ConnectException;
 import java.util.List;
 
+import static io.flowset.control.util.ExceptionUtils.isConnectionError;
 import static io.flowset.control.util.QueryUtils.*;
 
 @Service("control_DecisionInstanceService")
@@ -56,11 +56,11 @@ public class DecisionInstanceServiceImpl implements DecisionInstanceService {
         } catch (Exception e) {
             Throwable rootCause = ExceptionUtils.getRootCause(e);
             if (rootCause instanceof EngineNotSelectedException) {
-                log.warn("Unable to load deployments because BPM engine not selected");
+                log.warn("Unable to load historic DMN instances because BPM engine not selected");
                 return List.of();
             }
-            if (rootCause instanceof ConnectException) {
-                log.error("Unable to load deployments because of connection error: ", e);
+            if (isConnectionError(rootCause)) {
+                log.error("Unable to load  historic DMN instances because of connection error: ", e);
                 return List.of();
             }
             throw e;
@@ -90,7 +90,7 @@ public class DecisionInstanceServiceImpl implements DecisionInstanceService {
                 log.warn("Unable to load deployments because BPM engine not selected");
                 return null;
             }
-            if (rootCause instanceof ConnectException) {
+            if (isConnectionError(rootCause)) {
                 log.error("Unable to load deployments because of connection error: ", e);
                 return null;
             }

--- a/src/main/java/io/flowset/control/uicomponent/grid/ControlDataGridLoader.java
+++ b/src/main/java/io/flowset/control/uicomponent/grid/ControlDataGridLoader.java
@@ -1,0 +1,51 @@
+package io.flowset.control.uicomponent.grid;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.view.util.ComponentHelper;
+import io.jmix.flowui.xml.layout.loader.component.DataGridLoader;
+
+/**
+ * Extends the functionality of DataGridLoader by adding a default empty state component when no specific
+ * empty state component or text is provided.
+ */
+public class ControlDataGridLoader extends DataGridLoader {
+    public static final String GRID_EMPTY_CONTENT_DEFAULT_ID = "emptyStateBox";
+
+    protected ComponentHelper componentHelper;
+
+    @Override
+    protected void loadEmptyStateComponent() {
+        super.loadEmptyStateComponent();
+
+        if (resultComponent.getEmptyStateComponent() == null && resultComponent.getEmptyStateText() == null) {
+            Component emptyStateComponent = createDefaultEmptyStateComponent();
+
+            resultComponent.setEmptyStateComponent(emptyStateComponent);
+        }
+    }
+
+    protected Component createDefaultEmptyStateComponent() {
+        VerticalLayout emptyStateBox = new VerticalLayout();
+        emptyStateBox.setId(GRID_EMPTY_CONTENT_DEFAULT_ID);
+        emptyStateBox.setHeightFull();
+        emptyStateBox.setWidthFull();
+        emptyStateBox.addClassNames(LumoUtility.Gap.SMALL);
+        emptyStateBox.setAlignItems(FlexComponent.Alignment.CENTER);
+        emptyStateBox.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+
+        getComponentHelper().addNoDataGridStateComponents(emptyStateBox);
+
+        return emptyStateBox;
+    }
+
+    protected ComponentHelper getComponentHelper() {
+        if (componentHelper == null) {
+            componentHelper = applicationContext.getBean(ComponentHelper.class);
+        }
+        return componentHelper;
+    }
+
+}

--- a/src/main/java/io/flowset/control/util/ExceptionUtils.java
+++ b/src/main/java/io/flowset/control/util/ExceptionUtils.java
@@ -1,0 +1,17 @@
+package io.flowset.control.util;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+
+public class ExceptionUtils {
+
+    /**
+     * Determines whether the specified exception is related to a connection error.
+     *
+     * @param exception the exception to be checked for a connection error.
+     * @return true if the exception represents a connection error, otherwise - false.
+     */
+    public static boolean isConnectionError(Throwable exception) {
+        return exception instanceof ConnectException || exception instanceof SocketTimeoutException;
+    }
+}

--- a/src/main/java/io/flowset/control/view/AbstractListViewWithDelayedLoad.java
+++ b/src/main/java/io/flowset/control/view/AbstractListViewWithDelayedLoad.java
@@ -1,0 +1,153 @@
+package io.flowset.control.view;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.view.util.ComponentHelper;
+import io.jmix.flowui.Facets;
+import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.facet.Timer;
+import io.jmix.flowui.view.StandardListView;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * An abstract base class for list views with a delayed data loading mechanism.
+ * It extends <code>StandardListView</code> and incorporates features such as state management
+ * for displaying the loading process, error handling, and UI updates.
+ * This implementation adds an internal timer that loads data asynchronously.
+ * <br/>
+ * The following rules must be applied when implementing a view extending this view class:
+ * <ol>
+ *     <li>Data grid should contain an empty state component with id <code>emptyStateBox</code></li>
+ *     <li>Add invocation of data loader that loads an item list showing in the data grid in the implementation of <code>loadData</code> method</li>
+ *     <li>All actions triggering (e.g., refresh, filter applying) a data loading should call <code>startLoadData</code> method for async data loading</li>
+ *     <li>Method loading data in the data loader delegate should be wrapped in the <code>loadItemsWithStateHandling</code> method invocation.</li>
+ * </ol>
+ *
+ * @param <V> the type of the data being displayed in the list view
+ */
+public abstract class AbstractListViewWithDelayedLoad<V> extends StandardListView<V> {
+    protected static final String GRID_EMPTY_CONTENT_DEFAULT_ID = "emptyStateBox";
+
+    @Autowired
+    protected ComponentHelper componentHelper;
+
+    protected boolean isLoading = false;
+    protected String errorMessage;
+    protected boolean hasData = false;
+
+    protected Timer dataLoadTimer;
+    protected VerticalLayout emptyStateBox;
+
+    public AbstractListViewWithDelayedLoad() {
+        addInitListener(this::onInitInternal);
+        addBeforeShowListener(this::onBeforeShowInternal);
+        addReadyListener(this::onReadyInternal);
+    }
+
+    private void onReadyInternal(ReadyEvent readyEvent) {
+        dataLoadTimer.start();
+    }
+
+    private void onBeforeShowInternal(BeforeShowEvent beforeShowEvent) {
+        isLoading = true;
+        errorMessage = null;
+        updateGridState();
+    }
+
+    private void onInitInternal(InitEvent initEvent) {
+        Facets facets = getApplicationContext().getBean(Facets.class);
+        dataLoadTimer = facets.create(Timer.class);
+        dataLoadTimer.setId("dataLoadTimer");
+        dataLoadTimer.setDelay(2);
+        dataLoadTimer.setAutostart(false);
+        dataLoadTimer.setRepeating(false);
+        dataLoadTimer.addTimerActionListener(event -> handleDataLoading());
+        getViewFacets().addFacet(dataLoadTimer);
+
+        emptyStateBox = getContent().findComponent(GRID_EMPTY_CONTENT_DEFAULT_ID)
+                .map(component -> (VerticalLayout) component)
+                .orElseThrow(() -> new IllegalStateException("Unable to find empty grid component in %s by id %s".formatted(getClass(), GRID_EMPTY_CONTENT_DEFAULT_ID)));
+    }
+
+    /**
+     * Loads data by timer action.
+     */
+    protected void handleDataLoading() {
+        loadData();
+    }
+
+    /**
+     * Provides a loading of the data showing in the data grid.
+     */
+    protected abstract void loadData();
+
+    /**
+     * Loads items using the provided supplier while managing the state of loading, error handling, and
+     * updating the UI accordingly. Adjusts internal flags such as loading state, data presence,
+     * and stores any error messages encountered during the process.
+     *
+     * @param itemsSupplier a supplier providing the list of items to be loaded
+     * @return the list of loaded items if successful; or an empty list if an error occurs
+     */
+    protected List<V> loadItemsWithStateHandling(Supplier<List<V>> itemsSupplier) {
+        try {
+            List<V> data = itemsSupplier.get();
+            hasData = CollectionUtils.isNotEmpty(data);
+            return data;
+        } catch (EngineConnectionFailedException e) {
+            errorMessage = e.getMessage();
+            hasData = false;
+            return List.of();
+        } finally {
+            isLoading = false;
+            updateGridState();
+        }
+    }
+
+    /**
+     * Updates the grid empty component depending on the current state of data loading:
+     * <ul>
+     *     <li>If data loading is in progress - shows a loading indicator</li>
+     *     <li>If data is loaded but the list is empty - shows a "no data" component</li>
+     *     <li>If data loading is completed, but an error occurs - shows an error message as an empty data grid component</li>
+     *     <li>If data is loaded and the list is not empty - recalculate column widths in the data grid.</li>
+     * </ul>
+     */
+    protected void updateGridState() {
+        emptyStateBox.removeAll();
+        emptyStateBox.addClassNames(LumoUtility.Gap.SMALL);
+
+        if (isLoading) {
+            componentHelper.addLoadingGridStateComponents(emptyStateBox);
+        } else if (errorMessage != null) {
+            componentHelper.addErrorStateGridStateComponents(emptyStateBox, errorMessage);
+        } else if (!hasData) {
+            componentHelper.addNoDataGridStateComponents(emptyStateBox);
+        } else {
+            emptyStateBox.getParent()
+                    .ifPresent(component -> {
+                        if (component instanceof DataGrid<?> dataGrid) {
+                            dataGrid.recalculateColumnWidths();
+                        }
+                    });
+        }
+    }
+
+    /**
+     * Update states to "loading" and starts a time for loading data.
+     */
+    protected void startLoadData() {
+        dataLoadTimer.stop();
+
+        isLoading = true;
+        errorMessage = null;
+        updateGridState();
+
+        dataLoadTimer.start();
+    }
+}

--- a/src/main/java/io/flowset/control/view/decisiondefinition/DecisionDefinitionDetailView.java
+++ b/src/main/java/io/flowset/control/view/decisiondefinition/DecisionDefinitionDetailView.java
@@ -10,6 +10,8 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.exception.ViewEngineConnectionFailedException;
 import io.jmix.core.LoadContext;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.UiEventPublisher;
@@ -138,7 +140,11 @@ public class DecisionDefinitionDetailView extends StandardDetailView<DecisionDef
             final LoadContext<DecisionDefinitionData> loadContext) {
         DecisionDefinitionData item = decisionDefinitionDc.getItemOrNull();
         String id = item == null ? Objects.requireNonNull(loadContext.getId()).toString() : item.getId();
-        return decisionDefinitionService.getById(id);
+        try {
+            return decisionDefinitionService.getById(id);
+        } catch (EngineConnectionFailedException e) {
+            throw new ViewEngineConnectionFailedException(e, this);
+        }
     }
 
     @Subscribe("versionComboBox")

--- a/src/main/java/io/flowset/control/view/decisiondefinition/DecisionDefinitionListItemActionsFragment.java
+++ b/src/main/java/io/flowset/control/view/decisiondefinition/DecisionDefinitionListItemActionsFragment.java
@@ -2,37 +2,30 @@ package io.flowset.control.view.decisiondefinition;
 
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.RouteParameters;
 import io.jmix.flowui.ViewNavigators;
-import io.jmix.flowui.fragment.Fragment;
 import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
+import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
 import io.jmix.flowui.kit.component.button.JmixButton;
 import io.jmix.flowui.view.Subscribe;
 import io.flowset.control.entity.decisiondefinition.DecisionDefinitionData;
-import io.flowset.control.entity.processinstance.ProcessInstanceData;
-import io.flowset.control.view.processinstance.ProcessInstanceDetailView;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static io.jmix.flowui.component.UiComponentUtils.getCurrentView;
 
 @FragmentDescriptor("decision-definition-list-item-actions-fragment.xml")
-public class DecisionDefinitionListItemActionsFragment extends Fragment<HorizontalLayout> {
+@RendererItemContainer("decisionDefinitionDc")
+public class DecisionDefinitionListItemActionsFragment extends FragmentRenderer<HorizontalLayout, DecisionDefinitionData> {
 
     @Autowired
     private ViewNavigators viewNavigators;
-
-    protected DecisionDefinitionData decisionDefinitionData;
-
-    public void setDecisionDefinition(DecisionDefinitionData decisionDefinitionData) {
-        this.decisionDefinitionData = decisionDefinitionData;
-    }
 
     @Subscribe(id = "viewDetailsBtn", subject = "clickListener")
     public void onViewDetailsBtnClick(final ClickEvent<JmixButton> event) {
         viewNavigators.detailView(getCurrentView(), DecisionDefinitionData.class)
                 .withViewClass(DecisionDefinitionDetailView.class)
-                .withRouteParameters(new RouteParameters("id", decisionDefinitionData.getId()))
+                .withRouteParameters(new RouteParameters("id", item.getId()))
                 .withBackwardNavigation(true)
                 .navigate();
     }

--- a/src/main/java/io/flowset/control/view/deploymentdata/DeploymentDetailView.java
+++ b/src/main/java/io/flowset/control/view/deploymentdata/DeploymentDetailView.java
@@ -19,6 +19,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.exception.ViewEngineConnectionFailedException;
 import io.jmix.core.LoadContext;
 import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
@@ -201,7 +203,11 @@ public class DeploymentDetailView extends StandardDetailView<DeploymentData> {
         DeploymentData item = deploymentDataDc.getItemOrNull();
         String id = item == null ? Objects.requireNonNull(loadContext.getId()).toString() : item.getId();
 
-        return deploymentService.findById(id);
+        try {
+            return deploymentService.findById(id);
+        } catch (EngineConnectionFailedException e) {
+            throw new ViewEngineConnectionFailedException(e, this);
+        }
     }
 
     private void initResourcesDataGrid() {

--- a/src/main/java/io/flowset/control/view/incidentdata/IncidentDataDetailView.java
+++ b/src/main/java/io/flowset/control/view/incidentdata/IncidentDataDetailView.java
@@ -19,6 +19,8 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.exception.ViewEngineConnectionFailedException;
 import io.jmix.core.LoadContext;
 import io.jmix.core.Messages;
 import io.jmix.flowui.*;
@@ -174,7 +176,11 @@ public class IncidentDataDetailView extends StandardDetailView<IncidentData> {
     protected IncidentData incidentDataDlLoadDelegate(final LoadContext<IncidentData> loadContext) {
         Object id = loadContext.getId();
         if (id != null) {
-            return incidentService.findRuntimeIncidentById(id.toString());
+            try {
+                return incidentService.findRuntimeIncidentById(id.toString());
+            } catch (EngineConnectionFailedException e) {
+                throw new ViewEngineConnectionFailedException(e, this);
+            }
         }
         return null;
     }

--- a/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionDetailView.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionDetailView.java
@@ -13,6 +13,8 @@ import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.exception.ViewEngineConnectionFailedException;
 import io.jmix.core.LoadContext;
 import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
@@ -236,7 +238,11 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
     @Install(to = "processDefinitionDataDl", target = Target.DATA_LOADER)
     protected ProcessDefinitionData loadProcessDefinition(LoadContext<ProcessDefinitionData> loadContext) {
         String id = Objects.requireNonNull(loadContext.getId()).toString();
-        return processDefinitionService.getById(id);
+        try {
+            return processDefinitionService.getById(id);
+        } catch (EngineConnectionFailedException e) {
+            throw new ViewEngineConnectionFailedException(e, this);
+        }
     }
 
     @Subscribe(id = "processInstanceFilterDc", target = Target.DATA_CONTAINER)

--- a/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceDetailView.java
+++ b/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceDetailView.java
@@ -37,6 +37,8 @@ import io.flowset.control.entity.decisioninstance.HistoricDecisionInstanceShortD
 import io.flowset.control.entity.filter.DecisionInstanceFilter;
 import io.flowset.control.entity.processinstance.ProcessInstanceData;
 import io.flowset.control.entity.processinstance.ProcessInstanceState;
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.exception.ViewEngineConnectionFailedException;
 import io.flowset.control.service.activity.ActivityService;
 import io.flowset.control.service.decisioninstance.DecisionInstanceLoadContext;
 import io.flowset.control.service.decisioninstance.DecisionInstanceService;
@@ -205,7 +207,11 @@ public class ProcessInstanceDetailView extends StandardDetailView<ProcessInstanc
 
     @Install(to = "processInstanceDataDl", target = Target.DATA_LOADER)
     protected ProcessInstanceData processInstanceDataDlLoadDelegate(final LoadContext<ProcessInstanceData> loadContext) {
-        return processInstanceService.getProcessInstanceById(Objects.requireNonNull(loadContext.getId()).toString());
+        try {
+            return processInstanceService.getProcessInstanceById(Objects.requireNonNull(loadContext.getId()).toString());
+        } catch (EngineConnectionFailedException e) {
+            throw new ViewEngineConnectionFailedException(e, this);
+        }
     }
 
     @Install(to = "runtimeActivityInstancesDl", target = Target.DATA_LOADER)

--- a/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceListParamBinder.java
+++ b/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceListParamBinder.java
@@ -14,7 +14,6 @@ import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.facet.UrlQueryParametersFacet;
 import io.jmix.flowui.facet.urlqueryparameters.AbstractUrlQueryParametersBinder;
 import io.jmix.flowui.kit.component.button.JmixButton;
-import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.model.InstanceContainer;
 import io.flowset.control.entity.filter.ProcessInstanceFilter;
 import io.flowset.control.entity.processinstance.ProcessInstanceData;
@@ -34,17 +33,17 @@ public class ProcessInstanceListParamBinder extends AbstractUrlQueryParametersBi
     private static final String STATE_COLUMN_KEY = "state";
 
     private final InstanceContainer<ProcessInstanceFilter> filterDc;
-    private final CollectionLoader<ProcessInstanceData> processInstanceDl;
+    private final Runnable loadDelegate;
     private final ProcessInstanceStateHeaderFilter stateHeaderFilter;
     private final List<JmixButton> modeButtons;
 
     public ProcessInstanceListParamBinder(HorizontalLayout buttonsPanel,
                                           InstanceContainer<ProcessInstanceFilter> filterDc,
-                                          CollectionLoader<ProcessInstanceData> processInstanceDl,
+                                          Runnable loadDelegate,
                                           DataGrid<ProcessInstanceData> dataGrid) {
 
         this.filterDc = filterDc;
-        this.processInstanceDl = processInstanceDl;
+        this.loadDelegate = loadDelegate;
         this.stateHeaderFilter = Optional.ofNullable(dataGrid.getColumnByKey(STATE_COLUMN_KEY))
                 .map(column -> (ProcessInstanceStateHeaderFilter) column.getHeaderComponent())
                 .orElse(null);
@@ -123,7 +122,7 @@ public class ProcessInstanceListParamBinder extends AbstractUrlQueryParametersBi
         if (mode == null) {
             this.filterDc.getItem().setState(null);
             this.filterDc.getItem().setUnfinished(true);
-            this.processInstanceDl.load();
+            this.loadDelegate.run();
             return;
         }
 
@@ -131,17 +130,17 @@ public class ProcessInstanceListParamBinder extends AbstractUrlQueryParametersBi
             case ALL -> {
                 this.filterDc.getItem().setState(null);
                 this.filterDc.getItem().setUnfinished(null);
-                this.processInstanceDl.load();
+                this.loadDelegate.run();
             }
             case COMPLETED -> {
                 this.filterDc.getItem().setState(ProcessInstanceState.COMPLETED);
                 this.filterDc.getItem().setUnfinished(null);
-                this.processInstanceDl.load();
+                this.loadDelegate.run();
             }
             default -> {
                 this.filterDc.getItem().setState(null);
                 this.filterDc.getItem().setUnfinished(true);
-                this.processInstanceDl.load();
+                this.loadDelegate.run();
             }
         }
     }

--- a/src/main/java/io/flowset/control/view/util/ComponentHelper.java
+++ b/src/main/java/io/flowset/control/view/util/ComponentHelper.java
@@ -8,6 +8,7 @@ package io.flowset.control.view.util;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 import io.jmix.core.Messages;
 import io.jmix.core.metamodel.datatype.DatatypeFormatter;
@@ -100,5 +101,48 @@ public class ComponentHelper {
      */
     public String getProcessLabel(String processKey, Integer processVersion) {
         return messages.formatMessage("", "common.processDefinitionKeyAndVersion", processKey, processVersion);
+    }
+
+    /**
+     * Adds components to represent a "no data" state within the provided empty state container.
+     *
+     * @param emptyStateBox the container to which the "no data" state components will be added
+     */
+    public void addNoDataGridStateComponents(VerticalLayout emptyStateBox) {
+        Icon mailbox = VaadinIcon.MAILBOX.create();
+        mailbox.addClassNames("empty-grid-icon", LumoUtility.TextColor.TERTIARY);
+
+        Span noDataHeader = new Span(messages.getMessage("dataGrid.emptyState.noData"));
+        noDataHeader.addClassNames(LumoUtility.TextColor.SECONDARY, LumoUtility.FontSize.SMALL);
+        emptyStateBox.add(mailbox, noDataHeader);
+    }
+
+    /**
+     * Adds components to represent a "loading" state within the provided empty state container.
+     *
+     * @param emptyStateBox the container to which the "loading" state components will be added
+     */
+    public void addLoadingGridStateComponents(VerticalLayout emptyStateBox) {
+        emptyStateBox.add(new Span(messages.getMessage("dataGrid.empty.loading")));
+        emptyStateBox.add();
+    }
+
+    /**
+     * Adds components to represent an "error" state within the provided empty state container.
+     *
+     * @param emptyStateBox the container to which the "error" state components will be added
+     * @param errorText the error message text to display within the "error" state
+     */
+    public void addErrorStateGridStateComponents(VerticalLayout emptyStateBox, String errorText) {
+        Icon warningIcon = VaadinIcon.WARNING.create();
+        warningIcon.addClassNames("empty-grid-icon", LumoUtility.TextColor.ERROR);
+
+        Span headerError = new Span(messages.getMessage("dataGrid.empty.errorHeader"));
+        headerError.addClassNames(LumoUtility.TextColor.ERROR, LumoUtility.FontWeight.SEMIBOLD, LumoUtility.FontSize.MEDIUM);
+
+        Span errorMessage = new Span(errorText);
+        errorMessage.addClassNames(LumoUtility.TextColor.ERROR, LumoUtility.FontSize.SMALL);
+
+        emptyStateBox.add(warningIcon, headerError, errorMessage);
     }
 }

--- a/src/main/resources/io/flowset/control/messages_de.properties
+++ b/src/main/resources/io/flowset/control/messages_de.properties
@@ -32,11 +32,12 @@ calledProcessNotFound.description.invalidVersion=Version (%s) ist keine Zahl
 calledProcessNotFound.description.version=Version: %s
 calledProcessNotFound.description.versionTag=Versions-Tag: %s
 common.processDefinitionKeyAndVersion=%s (Version %s)
+dataGrid.empty.errorHeader=Daten konnten nicht geladen werden
+dataGrid.empty.loading=Laden...
+dataGrid.emptyState.noData=Keine Daten
 
 engineAvailable=Erfolgreich mit '%s' verbunden
 engineNotAvailable.title=Keine Verbindung zur Engine möglich
-exceptionHandler.RuntimeJobNotFoundException.description=Die Aufgabe wurde bereits abgeschlossen oder ist in der BPM-Engine nicht vorhanden (%s)
-exceptionHandler.RuntimeJobNotFoundException.title=Job not found
 engineNotAvailable.description=Antwortcode: %s
 engineNotAvailable.descriptionWithError=Fehlermeldung: %s
 engineNotAvailable.incorrectUrl=Falsche URL angegeben: %s
@@ -53,6 +54,10 @@ io.flowset.control.entity/ProcessExecutionGraphEntry.completedInstancesCount=Abg
 io.flowset.control.entity/ProcessExecutionGraphEntry.date=Datum
 io.flowset.control.entity/ProcessExecutionGraphEntry.id=ID
 io.flowset.control.entity/ProcessExecutionGraphEntry.startedInstancesCount=Gestartete Instanzen
+
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.defaultDescription=Es konnte keine Verbindung zur BPM-Engine hergestellt werden.\nBitte versuchen Sie es später erneut.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.engineDescription=Verbindung zur BPM-Engine über URL %s nicht möglich.\nBitte versuchen Sie es später erneut.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.header=BPM-Engine nicht verfügbar
 
 io.flowset.control.view.about/aboutProductView.title=Über
 io.flowset.control.view.about/buildLabel.text=Build:

--- a/src/main/resources/io/flowset/control/messages_en.properties
+++ b/src/main/resources/io/flowset/control/messages_en.properties
@@ -33,11 +33,12 @@ calledProcessNotFound.description.invalidVersion=Version (%s) is not a number
 calledProcessNotFound.description.version=Version: %s
 calledProcessNotFound.description.versionTag=Version tag: %s
 common.processDefinitionKeyAndVersion=%s (ver. %s)
+dataGrid.empty.errorHeader=Unable to load data
+dataGrid.empty.loading=Loading...
+dataGrid.emptyState.noData=No data
 
 engineAvailable=Successfully connected to '%s'
 engineNotAvailable.title=Unable connect to engine
-exceptionHandler.RuntimeJobNotFoundException.description=Job already completed or does not exist in the BPM engine (%s)
-exceptionHandler.RuntimeJobNotFoundException.title=Job not found
 engineNotAvailable.description=Response code: %s
 engineNotAvailable.descriptionWithError=Error message: %s
 engineNotAvailable.incorrectUrl=Incorrect URL specified: %s
@@ -55,6 +56,10 @@ io.flowset.control.entity/ProcessExecutionGraphEntry.date=Date
 io.flowset.control.entity/ProcessExecutionGraphEntry.id=Id
 io.flowset.control.entity/ProcessExecutionGraphEntry.startedInstancesCount=Started instances count
 
+
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.defaultDescription=Unable to connect to the BPM engine.\nPlease try again later.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.engineDescription=Unable to connect to the BPM engine by URL: %s.\nPlease try again later.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.header=BPM engine not available
 
 io.flowset.control.view.about/aboutProductView.title=About
 io.flowset.control.view.about/buildLabel.text=Build:

--- a/src/main/resources/io/flowset/control/messages_es.properties
+++ b/src/main/resources/io/flowset/control/messages_es.properties
@@ -32,11 +32,12 @@ calledProcessNotFound.description.invalidVersion=La versión (%s) no es un núme
 calledProcessNotFound.description.version=Versión: %s
 calledProcessNotFound.description.versionTag=Etiqueta de versión: %s
 common.processDefinitionKeyAndVersion=%s (ver. %s)
+dataGrid.empty.errorHeader=No se pueden cargar los datos
+dataGrid.empty.loading=Cargando...
+dataGrid.emptyState.noData=No hay datos
 
 engineAvailable=Conectado exitosamente a '%s'
 engineNotAvailable.title=No se puede conectar al motor
-exceptionHandler.RuntimeJobNotFoundException.description=La tarea ya se ha completado o no está presente en el motor BPM (%s)
-exceptionHandler.RuntimeJobNotFoundException.title=Trabajo no encontrado
 engineNotAvailable.description=Código de respuesta: %s
 engineNotAvailable.descriptionWithError=Mensaje de error: %s
 engineNotAvailable.incorrectUrl=URL incorrecta especificada: %s
@@ -53,6 +54,10 @@ io.flowset.control.entity/ProcessExecutionGraphEntry.completedInstancesCount=Ins
 io.flowset.control.entity/ProcessExecutionGraphEntry.date=Fecha
 io.flowset.control.entity/ProcessExecutionGraphEntry.id=Id
 io.flowset.control.entity/ProcessExecutionGraphEntry.startedInstancesCount=Instancias iniciadas
+
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.defaultDescription=No se puede conectar al motor BPM.\nInténtalo más tarde.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.engineDescription=No se puede conectar al motor BPM por URL: %s.\nInténtelo de nuevo más tarde.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.header=Motor BPM no disponible
 
 io.flowset.control.view.about/aboutProductView.title=Acerca de
 io.flowset.control.view.about/buildLabel.text=Build:

--- a/src/main/resources/io/flowset/control/messages_ru.properties
+++ b/src/main/resources/io/flowset/control/messages_ru.properties
@@ -32,11 +32,12 @@ calledProcessNotFound.description.invalidVersion=Версия (%s) не явля
 calledProcessNotFound.description.version=Версия: %s
 calledProcessNotFound.description.versionTag=Тег версии: %s
 common.processDefinitionKeyAndVersion=%s (вер. %s)
+dataGrid.empty.errorHeader=Не удалось загрузить данные
+dataGrid.empty.loading=Загрузка...
+dataGrid.emptyState.noData=Нет данных
 
 engineAvailable=Успешно подключено к '%s'
 engineNotAvailable.title=Не удалось подключиться к BPM-движку
-exceptionHandler.RuntimeJobNotFoundException.description=Задание уже выполнено или не существует в BPM-движке (%s)
-exceptionHandler.RuntimeJobNotFoundException.title=Задание не найдено
 engineNotAvailable.description=Код ответа: %s
 engineNotAvailable.descriptionWithError=Ошибка: %s
 engineNotAvailable.incorrectUrl=Указан некорректный URL: %s
@@ -47,6 +48,10 @@ engineNotAvailable.emptyAuthPassword=Не указан пароль для ау�
 io.flowset.control.action/copyComponentValueAction.copied=Значение скопировано!
 io.flowset.control.action/copyComponentValueAction.copyFailed=Не удалось скопировать значение!
 io.flowset.control.action/copyComponentValueAction.errorMessage=Компонент для копирования значения не установлен!
+
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.defaultDescription=Не удалось подключиться к BPM-движку.\nПожалуйста, попробуйте позже.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.engineDescription=Не удалось подключиться к BPM-движку по URL: %s.\nПожалуйста, попробуйте позже.
+io.flowset.control.handler/exceptionDialog.engineNotAvailable.header=BPM-движок недоступен
 
 io.flowset.control.view.about/aboutProductView.title=О продукте
 io.flowset.control.view.about/buildLabel.text=Сборка:

--- a/src/main/resources/io/flowset/control/view/alltasks/all-tasks-view.xml
+++ b/src/main/resources/io/flowset/control/view/alltasks/all-tasks-view.xml
@@ -14,7 +14,9 @@
         <instance id="userTaskFilterDc" class="io.flowset.control.entity.filter.UserTaskFilter"/>
     </data>
     <facets>
-        <dataLoadCoordinator auto="true"/>
+        <urlQueryParameters>
+            <pagination component="tasksPagination"/>
+        </urlQueryParameters>
     </facets>
     <actions>
         <action id="applyFilter" icon="SEARCH" text="msg:///actions.Apply"
@@ -110,6 +112,9 @@
                         <column property="assignee" autoWidth="true"/>
                         <column key="actions" autoWidth="true" sortable="false" flexGrow="0"/>
                     </columns>
+                    <emptyStateComponent>
+                        <vbox id="emptyStateBox" height="100%" alignItems="CENTER" justifyContent="CENTER" width="100%"/>
+                    </emptyStateComponent>
                 </dataGrid>
             </vbox>
         </hbox>

--- a/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-list-item-actions-fragment.xml
+++ b/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-list-item-actions-fragment.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="decisionDefinitionDc" class="io.flowset.control.entity.decisiondefinition.DecisionDefinitionData"/>
+    </data>
     <content>
         <hbox spacing="false" padding="false" justifyContent="END">
             <button id="viewDetailsBtn"

--- a/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-list-view.xml
@@ -35,7 +35,7 @@
                         <checkbox property="latestVersionOnly" id="lastVersionOnlyCb"
                                   label="msg://decisionDefinitionList.lastVersionOnly"/>
 
-                        <icon icon="QUESTION_CIRCLE" id="allVersionsContextHelp" size="1em" alignSelf="CENTER">
+                        <icon icon="QUESTION_CIRCLE" id="allVersionsContextHelp" size="0.85em" alignSelf="CENTER" classNames="text-secondary">
                             <tooltip text="msg://keyAndLatestVersionOnly.tooltip"/>
                         </icon>
                     </hbox>
@@ -70,8 +70,13 @@
                 <column property="name" autoWidth="true" flexGrow="1"/>
                 <column property="key" autoWidth="true" flexGrow="1"/>
                 <column property="version"/>
-                <column key="actions" sortable="false" autoWidth="true" flexGrow="0"/>
+                <column key="actions" sortable="false" autoWidth="true" flexGrow="0">
+                    <fragmentRenderer class="io.flowset.control.view.decisiondefinition.DecisionDefinitionListItemActionsFragment"/>
+                </column>
             </columns>
+            <emptyStateComponent>
+                <vbox id="emptyStateBox" height="100%" alignItems="CENTER" justifyContent="CENTER" width="100%"/>
+            </emptyStateComponent>
         </dataGrid>
     </layout>
 </view>

--- a/src/main/resources/io/flowset/control/view/deploymentdata/deployment-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/deploymentdata/deployment-list-view.xml
@@ -76,6 +76,9 @@
                 <column property="tenantId"/>
                 <column key="actions" sortable="false" editable="false" autoWidth="true" flexGrow="0"/>
             </columns>
+            <emptyStateComponent>
+                <vbox id="emptyStateBox" height="100%" alignItems="CENTER" justifyContent="CENTER" width="100%"/>
+            </emptyStateComponent>
         </dataGrid>
     </layout>
 </view>

--- a/src/main/resources/io/flowset/control/view/incidentdata/incident-data-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/incidentdata/incident-data-list-view.xml
@@ -47,6 +47,9 @@
                 <column property="type" autoWidth="true" flexGrow="0"/>
                 <column key="actions" sortable="false" autoWidth="true" flexGrow="0"/>
             </columns>
+            <emptyStateComponent>
+                <vbox id="emptyStateBox" height="100%" alignItems="CENTER" justifyContent="CENTER" width="100%"/>
+            </emptyStateComponent>
         </dataGrid>
         <hbox id="lookupActions" visible="false">
             <button id="selectBtn" action="selectAction"/>

--- a/src/main/resources/io/flowset/control/view/processdefinition/process-definition-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/process-definition-list-view.xml
@@ -91,6 +91,9 @@
                         flexGrow="1"/>
                 <column key="actions" sortable="false" editable="false" autoWidth="true" flexGrow="0"/>
             </columns>
+            <emptyStateComponent>
+                <vbox id="emptyStateBox" height="100%" alignItems="CENTER" justifyContent="CENTER" width="100%"/>
+            </emptyStateComponent>
         </dataGrid>
     </layout>
 </view>

--- a/src/main/resources/io/flowset/control/view/processinstance/process-instance-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/processinstance/process-instance-list-view.xml
@@ -13,7 +13,6 @@
         <instance id="processInstanceFilterDc" class="io.flowset.control.entity.filter.ProcessInstanceFilter"/>
     </data>
     <facets>
-        <dataLoadCoordinator auto="true"/>
         <urlQueryParameters id="urlQueryParameters">
             <pagination component="processInstancePagination"/>
         </urlQueryParameters>
@@ -56,6 +55,9 @@
                 <column property="endTime" flexGrow="1" autoWidth="true"/>
                 <column key="actions" sortable="false" autoWidth="true" flexGrow="0"/>
             </columns>
+            <emptyStateComponent>
+                <vbox id="emptyStateBox" height="100%" alignItems="CENTER" justifyContent="CENTER" width="100%"/>
+            </emptyStateComponent>
         </dataGrid>
     </layout>
 </view>

--- a/src/test/java/io/flowset/control/service/deployment/Camunda7DeploymentServiceTest.java
+++ b/src/test/java/io/flowset/control/service/deployment/Camunda7DeploymentServiceTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.deployment;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.jmix.core.Resources;
 import io.flowset.control.entity.deployment.DeploymentData;
 import io.flowset.control.exception.RemoteEngineParseException;
@@ -109,6 +110,21 @@ public class Camunda7DeploymentServiceTest extends AbstractCamunda7IntegrationTe
     }
 
     @Test
+    @DisplayName("EngineConnectionFailedException thrown when deploy a valid BPMN 2.0 if engine is not available")
+    void givenResourceNameAndValidaBpmnXmlNotAvailableEngine_whenDeployWithContent_thenExceptionThrown() {
+        //given
+        String resourceName = "contractApproval.bpmn";
+        String bpmnXml = getResource("test_support/contractApproval.bpmn");
+        DeploymentContext deploymentContext = new DeploymentContext(resourceName, new ByteArrayInputStream(bpmnXml.getBytes(StandardCharsets.UTF_8)));
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() -> deploymentService.createDeployment(deploymentContext))
+                .isInstanceOf(EngineConnectionFailedException.class);
+    }
+
+    @Test
     @DisplayName("Find deployment by existing id")
     void givenExistingDeployment_whenFindById_thenDeploymentReturned() {
         //given
@@ -123,6 +139,19 @@ public class Camunda7DeploymentServiceTest extends AbstractCamunda7IntegrationTe
         assertThat(foundDeployment.getName()).isEqualTo("supportRequest.bpmn");
         assertThat(foundDeployment.getSource()).isNull();
         assertThat(foundDeployment.getDeploymentTime()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when find existing deployment by id if engine is not available")
+    void givenExistingDeploymentNotAvailableEngine_whenFindById_thenExceptionThrown() {
+        //given
+        DeploymentResultDto deployment = camundaRestTestHelper.createDeployment(camunda7, "test_support/supportRequest.bpmn");
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() -> deploymentService.findById(deployment.getId()))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     private String getResource(String name) {

--- a/src/test/java/io/flowset/control/service/incident/Camunda7IncidentServiceFindAllTest.java
+++ b/src/test/java/io/flowset/control/service/incident/Camunda7IncidentServiceFindAllTest.java
@@ -7,6 +7,7 @@ package io.flowset.control.service.incident;
 
 import io.flowset.control.entity.incident.HistoricIncidentData;
 import io.flowset.control.entity.incident.IncidentData;
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -26,8 +27,7 @@ import org.springframework.context.ApplicationContext;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -63,8 +63,8 @@ public class Camunda7IncidentServiceFindAllTest extends AbstractCamunda7Integrat
     }
 
     @Test
-    @DisplayName("Empty list with runtime incidents is returned if selected engine is not available")
-    void givenEmptyLoadContextAndNotAvailableEngine_whenFindRuntimeIncidents_thenEmptyListReturned() {
+    @DisplayName("EngineConnectionFailedException is thrown when loading runtime incidents if selected engine is not available")
+    void givenEmptyLoadContextAndNotAvailableEngine_whenFindRuntimeIncidents_thenExceptionThrown() {
         //given
         CamundaSampleDataManager camundaSampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7);
         camundaSampleDataManager.deploy("test_support/testFailedJobIncident.bpmn")
@@ -75,11 +75,9 @@ public class Camunda7IncidentServiceFindAllTest extends AbstractCamunda7Integrat
 
         IncidentLoadContext loadContext = new IncidentLoadContext();
 
-        //when
-        List<IncidentData> runtimeIncidents = incidentService.findRuntimeIncidents(loadContext);
-
-        //then
-        assertThat(runtimeIncidents).isEmpty();
+        //when and then
+        assertThatThrownBy(() -> incidentService.findRuntimeIncidents(loadContext))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test

--- a/src/test/java/io/flowset/control/service/job/Camunda7JobServiceFindAllTest.java
+++ b/src/test/java/io/flowset/control/service/job/Camunda7JobServiceFindAllTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.job;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.jmix.core.DataManager;
 import io.flowset.control.entity.filter.JobFilter;
 import io.flowset.control.entity.job.JobData;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
 @SpringBootTest
@@ -118,6 +120,24 @@ public class Camunda7JobServiceFindAllTest extends AbstractCamunda7IntegrationTe
 
         //then
         assertThat(jobs).hasSize(expectedCount);
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when find all jobs if engine is not available")
+    void givenExistingJobsAndNotAvailableEngine_whenFinAll_thenExceptionThrown() {
+        //given
+        applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testJobsListLoad.bpmn")
+                .startByKey("testJobsListLoad");
+
+        JobLoadContext loadContext = new JobLoadContext();
+
+        camunda7.stop();
+
+
+        //when and then
+        assertThatThrownBy(() -> jobService.findAll(loadContext))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     static Stream<Arguments> provideValidPaginationData() {

--- a/src/test/java/io/flowset/control/service/processdefinition/Camunda7ProcessDefinitionDeleteTest.java
+++ b/src/test/java/io/flowset/control/service/processdefinition/Camunda7ProcessDefinitionDeleteTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.processdefinition;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.exception.RemoteProcessEngineException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
@@ -67,6 +68,48 @@ public class Camunda7ProcessDefinitionDeleteTest extends AbstractCamunda7Integra
     }
 
     @Test
+    @DisplayName("Delete all active process version but not related active instances by id")
+    void givenActiveProcessVersionWithActiveInstances_whenDeleteByKeyWithoutInstances_thenExceptionThrownAndProcessNotDeleted() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning")
+                .deploy("test_support/testVisitPlanningV2.bpmn")
+                .startByKey("visitPlanning");
+
+        String v1 = sampleDataManager.getDeployedProcessVersions("visitPlanning").get(0);
+        String v2 = sampleDataManager.getDeployedProcessVersions("visitPlanning").get(1);
+
+        //when and then
+        assertThatThrownBy(() -> {
+            processDefinitionService.deleteAllVersionsByKey("visitPlanning", false);
+        }).isInstanceOf(RemoteProcessEngineException.class);
+
+
+        Boolean existsV1 = camundaRestTestHelper.existsProcessById(camunda7, v1);
+        Boolean existsV2 = camundaRestTestHelper.existsProcessById(camunda7, v2);
+        assertThat(existsV1).isTrue();
+        assertThat(existsV2).isTrue();
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when delete all versions by key if engine is not available")
+    void givenExistingProcessVersionsAndNotAvailableEngine_whenDeleteAllVersionsByKey_thenExceptionThrown() {
+        //given
+        applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning")
+                .deploy("test_support/testVisitPlanningV2.bpmn")
+                .startByKey("visitPlanning");
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() ->  processDefinitionService.deleteAllVersionsByKey("visitPlanning", true))
+                .isInstanceOf(EngineConnectionFailedException.class);
+    }
+
+    @Test
     @DisplayName("Delete active process version and related active instances by id")
     void givenActiveProcessVersionWithActiveInstances_whenDeleteByIdWithInstances_thenExceptionThrownAndProcessNotDeleted() {
         //given
@@ -88,5 +131,23 @@ public class Camunda7ProcessDefinitionDeleteTest extends AbstractCamunda7Integra
         List<HistoricProcessInstanceDto> historyInstances = camundaRestTestHelper.findHistoryProcessInstancesById(camunda7, processVersionId);
         assertThat(historyInstances).isEmpty();
 
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when delete process version by id if engine is not available")
+    void givenExistingProcessVersionAndNotAvailableEngine_whenDeleteById_thenExceptionThrown() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/vacationApproval.bpmn")
+                .startByKey("vacation_approval");
+
+        String processVersionId = sampleDataManager.getDeployedProcessVersions("vacation_approval").get(0);
+
+        camunda7.stop();
+
+
+        //when and then
+        assertThatThrownBy(() -> processDefinitionService.deleteById(processVersionId, true))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 }

--- a/src/test/java/io/flowset/control/service/processdefinition/Camunda7ProcessDefinitionFindAllTest.java
+++ b/src/test/java/io/flowset/control/service/processdefinition/Camunda7ProcessDefinitionFindAllTest.java
@@ -6,6 +6,7 @@
 package io.flowset.control.service.processdefinition;
 
 import io.flowset.control.entity.processdefinition.ProcessDefinitionData;
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
 @SpringBootTest
@@ -65,8 +67,8 @@ public class Camunda7ProcessDefinitionFindAllTest extends AbstractCamunda7Integr
     }
 
     @Test
-    @DisplayName("Empty list returned if engine is not available")
-    void givenDeployedProcessesAndNotAvailableEngine_whenFindAll_thenEmptyListReturned() {
+    @DisplayName("EngineConnectionFailedException thrown when get process definitions list if engine is not available")
+    void givenDeployedProcessesAndNotAvailableEngine_whenFindAll_thenExceptionThrown() {
         //given
         applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
                 .deploy("test_support/vacationApproval.bpmn");
@@ -75,11 +77,9 @@ public class Camunda7ProcessDefinitionFindAllTest extends AbstractCamunda7Integr
 
         ProcessDefinitionLoadContext loadContext = new ProcessDefinitionLoadContext();
 
-        //when
-        List<ProcessDefinitionData> foundProcesses = processDefinitionService.findAll(loadContext);
-
-        //then
-        assertThat(foundProcesses).isEmpty();
+        //when and then
+        assertThatThrownBy(() -> processDefinitionService.findAll(loadContext))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test

--- a/src/test/java/io/flowset/control/service/processdefinition/Camunda7ProcessDefinitionServiceTest.java
+++ b/src/test/java/io/flowset/control/service/processdefinition/Camunda7ProcessDefinitionServiceTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.processdefinition;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.jmix.core.DataManager;
 import io.flowset.control.entity.processdefinition.ProcessDefinitionData;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
@@ -25,8 +26,7 @@ import org.springframework.context.ApplicationContext;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -204,19 +204,17 @@ public class Camunda7ProcessDefinitionServiceTest extends AbstractCamunda7Integr
     }
 
     @Test
-    @DisplayName("Process version not found if engine is not available")
-    void givenDeployedProcessIdAndStoppedEngine_whenGetById_thenNullReturned() {
+    @DisplayName("EngineConnectionFailedException when find process version by id if engine is not available")
+    void givenDeployedProcessIdAndStoppedEngine_whenGetById_thenExceptionThrown() {
         //given
         DeploymentResultDto deploymentResultDto = camundaRestTestHelper.createDeployment(camunda7, "test_support/testVisitPlanningV1.bpmn");
         String processId = deploymentResultDto.getDeployedProcessDefinitions().keySet().iterator().next();
 
         camunda7.stop();
 
-        //when
-        ProcessDefinitionData foundProcess = processDefinitionService.getById(processId);
-
-        //then
-        assertThat(foundProcess).isNull();
+        //when and then
+        assertThatThrownBy(() -> processDefinitionService.getById(processId))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
 
@@ -324,18 +322,16 @@ public class Camunda7ProcessDefinitionServiceTest extends AbstractCamunda7Integr
     }
 
     @Test
-    @DisplayName("Zero is returned as process versions count if engine is not available")
-    void givenDeployedProcessAndNotAvailableEngine_whenGetCount_thenZeroReturned() {
+    @DisplayName("EngineConnectionFailedException thrown when get process versions count if engine is not available")
+    void givenDeployedProcessAndNotAvailableEngine_whenGetCount_thenExceptionThrown() {
         //given
         camundaRestTestHelper.createDeployment(camunda7, "test_support/testVisitPlanningV1.bpmn");
 
         camunda7.stop();
 
-        //when
-        long processCount = processDefinitionService.getCount(null);
-
-        //then
-        assertThat(processCount).isZero();
+        //when and then
+        assertThatThrownBy(() -> processDefinitionService.getCount(null))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test

--- a/src/test/java/io/flowset/control/service/processinstance/Camunda7MigrationServiceTest.java
+++ b/src/test/java/io/flowset/control/service/processinstance/Camunda7MigrationServiceTest.java
@@ -1,0 +1,116 @@
+package io.flowset.control.service.processinstance;
+
+import io.flowset.control.exception.EngineConnectionFailedException;
+import io.flowset.control.test_support.AuthenticatedAsAdmin;
+import io.flowset.control.test_support.RunningEngine;
+import io.flowset.control.test_support.WithRunningEngine;
+import io.flowset.control.test_support.camunda7.AbstractCamunda7IntegrationTest;
+import io.flowset.control.test_support.camunda7.Camunda7Container;
+import io.flowset.control.test_support.camunda7.CamundaSampleDataManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@SpringBootTest
+@ExtendWith(AuthenticatedAsAdmin.class)
+@WithRunningEngine
+public class Camunda7MigrationServiceTest extends AbstractCamunda7IntegrationTest {
+    @RunningEngine
+    static Camunda7Container<?> camunda7;
+
+    @Autowired
+    MigrationService migrationService;
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when validate definition migration plan if engine is not available")
+    void givenTwoProcessVersionsAndNotAvailableEngine_whenValidateMigrationPlan_thenExceptionThrown() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning")
+                .deploy("test_support/testVisitPlanningV2.bpmn");
+
+        List<String> visitPlanningProcessVersions = sampleDataManager.getDeployedProcessVersions("visitPlanning");
+        String srcProcessVersion = visitPlanningProcessVersions.get(0);
+        String targetProcessVersion = visitPlanningProcessVersions.get(1);
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() -> migrationService.validateMigrationOfProcessInstances(srcProcessVersion, targetProcessVersion))
+                .isInstanceOf(EngineConnectionFailedException.class);
+    }
+
+    @Test
+    @DisplayName("No errors when create a process definition migration plan")
+    void givenTwoProcessVersions_whenValidateMigrationPlan_thenNoErrorReturned() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning")
+                .deploy("test_support/testVisitPlanningV2.bpmn");
+
+        List<String> visitPlanningProcessVersions = sampleDataManager.getDeployedProcessVersions("visitPlanning");
+        String srcProcessVersion = visitPlanningProcessVersions.get(0);
+        String targetProcessVersion = visitPlanningProcessVersions.get(1);
+
+        //when
+        List<String> migrationValidationErrors = migrationService.validateMigrationOfProcessInstances(srcProcessVersion, targetProcessVersion);
+
+        //then
+        assertThat(migrationValidationErrors).isEmpty();
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when validate instance migration plan if engine is not available")
+    void givenTwoProcessVersionsAndInstanceAndNotAvailableEngine_whenValidateMigrationPlan_thenExceptionThrown() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning")
+                .deploy("test_support/testVisitPlanningV2.bpmn");
+
+        List<String> visitPlanningProcessVersions = sampleDataManager.getDeployedProcessVersions("visitPlanning");
+
+        String instanceId = sampleDataManager.getStartedInstances("visitPlanning").get(0);
+        String targetProcessVersion = visitPlanningProcessVersions.get(1);
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() -> migrationService.validateMigrationOfSingleProcessInstance(instanceId, targetProcessVersion))
+                .isInstanceOf(EngineConnectionFailedException.class);
+    }
+
+    @Test
+    @DisplayName("No errors when create a process instance migration plan")
+    void givenTwoProcessVersionsAndInstance_whenValidateMigrationPlan_thenNoErrorReturned() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning")
+                .deploy("test_support/testVisitPlanningV2.bpmn");
+
+        List<String> visitPlanningProcessVersions = sampleDataManager.getDeployedProcessVersions("visitPlanning");
+
+        String instanceId = sampleDataManager.getStartedInstances("visitPlanning").get(0);
+        String targetProcessVersion = visitPlanningProcessVersions.get(1);
+
+        //when
+        List<String> migrationValidationErrors = migrationService.validateMigrationOfSingleProcessInstance(instanceId, targetProcessVersion);
+
+        //then
+        assertThat(migrationValidationErrors).isEmpty();
+    }
+}

--- a/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceActivateTest.java
+++ b/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceActivateTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.processinstance;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -23,6 +24,7 @@ import org.springframework.context.ApplicationContext;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -68,6 +70,26 @@ public class Camunda7ProcessInstanceActivateTest extends AbstractCamunda7Integra
     }
 
     @Test
+    @DisplayName("EngineConnectionFailedException thrown when activate instance by id if engine is not available")
+    void givenSuspendedInstanceAndNotAvailableEngine_whenActivateById_thenExceptionThrown() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning");
+
+        String processId = sampleDataManager.getDeployedProcessVersions("visitPlanning").get(0);
+        String instanceId = camundaRestTestHelper.getRuntimeInstancesById(camunda7, processId).get(0).getId();
+
+        camundaRestTestHelper.suspendInstanceById(camunda7, instanceId);
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() -> processInstanceService.activateById(instanceId))
+                .isInstanceOf(EngineConnectionFailedException.class);
+    }
+
+    @Test
     @DisplayName("Activate asynchronously existing suspended instances by ids")
     void givenExistingSuspendedInstances_whenActivateByIdsAsync_thenInstancesActivated() {
         //given
@@ -90,6 +112,27 @@ public class Camunda7ProcessInstanceActivateTest extends AbstractCamunda7Integra
                 .hasSize(5)
                 .containsExactlyInAnyOrderElementsOf(suspendedInstanceIds);
 
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when activate instances async if engine is not available")
+    void givenSuspendedInstancesAndNotAvailableEngine_whenActivateByIdsAsync_thenExceptionThrown() {
+        //given
+        CamundaSampleDataManager sampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testVisitPlanningV1.bpmn")
+                .startByKey("visitPlanning", 5);
+
+        String processId = sampleDataManager.getDeployedProcessVersions("visitPlanning").get(0);
+        camundaRestTestHelper.suspendInstanceByProcessId(camunda7, processId);
+
+        List<String> suspendedInstanceIds = camundaRestTestHelper.getSuspendedInstancesByProcessId(camunda7, processId);
+
+        camunda7.stop();
+
+
+        //when and then
+        assertThatThrownBy(() ->  processInstanceService.activateByIdsAsync(suspendedInstanceIds))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     private void waitForBatchExecution() {

--- a/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceFindAllTest.java
+++ b/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceFindAllTest.java
@@ -6,6 +6,7 @@
 package io.flowset.control.service.processinstance;
 
 import io.flowset.control.entity.processinstance.ProcessInstanceData;
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -81,8 +83,8 @@ public class Camunda7ProcessInstanceFindAllTest extends AbstractCamunda7Integrat
     }
 
     @Test
-    @DisplayName("Empty list returned if selected engine is not available")
-    void givenRunningProcessInstancesAndNotAvailableEngine_whenFindAllHistoricInstances_thenEmptyListReturned() {
+    @DisplayName("EngineConnectionFailedException thrown when get instance list if selected engine is not available")
+    void givenRunningProcessInstancesAndNotAvailableEngine_whenFindAllHistoricInstances_thenExceptionThrown() {
         //given
         CamundaSampleDataManager camundaSampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7);
         camundaSampleDataManager.deploy("test_support/vacationApproval.bpmn")
@@ -92,12 +94,9 @@ public class Camunda7ProcessInstanceFindAllTest extends AbstractCamunda7Integrat
 
         ProcessInstanceLoadContext loadContext = new ProcessInstanceLoadContext();
 
-        //when
-        List<ProcessInstanceData> instances = processInstanceService.findAllHistoricInstances(loadContext);
-
-        //then
-        assertThat(instances).isNotNull()
-                .isEmpty();
+        //when adn then
+        assertThatThrownBy(() -> processInstanceService.findAllHistoricInstances(loadContext))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @ParameterizedTest

--- a/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceServiceTest.java
+++ b/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceServiceTest.java
@@ -7,6 +7,7 @@ package io.flowset.control.service.processinstance;
 
 import io.flowset.control.entity.processinstance.ProcessInstanceData;
 import io.flowset.control.entity.processinstance.ProcessInstanceState;
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -24,6 +25,7 @@ import org.springframework.context.ApplicationContext;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -60,8 +62,8 @@ public class Camunda7ProcessInstanceServiceTest extends AbstractCamunda7Integrat
     }
 
     @Test
-    @DisplayName("Zero is returned as process instances count if engine is not available")
-    void givenRunningInstanceAndNotAvailableEngine_whenGetHistoricInstancesCount_thenZeroReturned() {
+    @DisplayName("EngineConnectionFailedException thrown when get process instances count if engine is not available")
+    void givenRunningInstanceAndNotAvailableEngine_whenGetHistoricInstancesCount_thenExceptionThrown() {
         //given
         applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
                 .deploy("test_support/testVisitPlanningV1.bpmn")
@@ -69,11 +71,9 @@ public class Camunda7ProcessInstanceServiceTest extends AbstractCamunda7Integrat
 
         camunda7.stop();
 
-        //when
-        long instancesCount = processInstanceService.getHistoricInstancesCount(null);
-
-        //then
-        assertThat(instancesCount).isZero();
+        //when and then
+        assertThatThrownBy(() -> processInstanceService.getHistoricInstancesCount(null))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class Camunda7ProcessInstanceServiceTest extends AbstractCamunda7Integrat
     }
 
     @Test
-    @DisplayName("Null returned for existing instance if selected engine is not available")
+    @DisplayName("EngineConnectionFailedException thrown when get existing instance if selected engine is not available")
     void givenRunningInstanceAndNotAvailableEngine_whenGetProcessInstanceById_thenNullReturned() {
         //given
         applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
@@ -122,11 +122,9 @@ public class Camunda7ProcessInstanceServiceTest extends AbstractCamunda7Integrat
 
         camunda7.stop();
 
-        //when
-        ProcessInstanceData foundInstance = processInstanceService.getProcessInstanceById(instanceId);
-
-        //then
-        assertThat(foundInstance).isNull();
+        //when and then
+        assertThatThrownBy(() -> processInstanceService.getProcessInstanceById(instanceId))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test

--- a/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceStartTest.java
+++ b/src/test/java/io/flowset/control/service/processinstance/Camunda7ProcessInstanceStartTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.processinstance;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.jmix.core.DataManager;
 import io.flowset.control.entity.processinstance.ProcessInstanceData;
 import io.flowset.control.entity.variable.VariableInstanceData;
@@ -29,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.lang.Nullable;
 
-import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -56,7 +56,7 @@ public class Camunda7ProcessInstanceStartTest extends AbstractCamunda7Integratio
     DataManager dataManager;
 
     @Test
-    @DisplayName("ConnectionException is thrown on process instance start if selected engine is not available")
+    @DisplayName("EngineConnectionFailedException is thrown on process instance start if selected engine is not available")
     void givenDeployedProcessAndNotAvailableEngine_whenStartByProcessId_thenStartedInstanceDataReturned() {
         //given
         DeploymentResultDto deploymentResultDto = camundaRestTestHelper.createDeployment(camunda7, "test_support/vacationApproval.bpmn");
@@ -68,7 +68,7 @@ public class Camunda7ProcessInstanceStartTest extends AbstractCamunda7Integratio
 
         //when and then
         assertThatThrownBy(() -> processInstanceService.startProcessByDefinitionId(processId, variables, null))
-                .hasCauseInstanceOf(ConnectException.class);
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test

--- a/src/test/java/io/flowset/control/service/usertask/Camunda7UserTaskFindAllTest.java
+++ b/src/test/java/io/flowset/control/service/usertask/Camunda7UserTaskFindAllTest.java
@@ -6,6 +6,7 @@
 package io.flowset.control.service.usertask;
 
 import io.flowset.control.entity.UserTaskData;
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -27,8 +28,7 @@ import org.springframework.context.ApplicationContext;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -47,8 +47,8 @@ public class Camunda7UserTaskFindAllTest extends AbstractCamunda7IntegrationTest
     CamundaRestTestHelper camundaRestTestHelper;
 
     @Test
-    @DisplayName("Empty list with tasks is returned if selected engine is not available")
-    void givenEmptyLoadContextAndNotAvailableEngine_whenFindRuntimeTasks_thenNoUserTasksReturned() {
+    @DisplayName("EngineConnectionFailedException thrown when load runtime user tasks if selected engine is not available")
+    void givenEmptyLoadContextAndNotAvailableEngine_whenFindRuntimeTasks_thenExceptionThrown() {
         //given
         CamundaSampleDataManager camundaSampleDataManager = applicationContext.getBean(CamundaSampleDataManager.class, camunda7);
         camundaSampleDataManager.deploy("test_support/testUserTaskWithoutAssignee.bpmn")
@@ -60,11 +60,9 @@ public class Camunda7UserTaskFindAllTest extends AbstractCamunda7IntegrationTest
 
         UserTaskLoadContext userTaskLoadContext = new UserTaskLoadContext();
 
-        //when
-        List<UserTaskData> foundUserTasks = userTaskService.findRuntimeTasks(userTaskLoadContext);
-
-        //then
-        assertThat(foundUserTasks).isEmpty();
+        //when and then
+        assertThatThrownBy(() -> userTaskService.findRuntimeTasks(userTaskLoadContext))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 
     @Test

--- a/src/test/java/io/flowset/control/service/usertask/Camunda7UserTaskSetAssigneeTest.java
+++ b/src/test/java/io/flowset/control/service/usertask/Camunda7UserTaskSetAssigneeTest.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.service.usertask;
 
+import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.test_support.AuthenticatedAsAdmin;
 import io.flowset.control.test_support.RunningEngine;
 import io.flowset.control.test_support.WithRunningEngine;
@@ -21,6 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 @ExtendWith(AuthenticatedAsAdmin.class)
@@ -99,5 +101,22 @@ public class Camunda7UserTaskSetAssigneeTest extends AbstractCamunda7Integration
         assertThat(foundTask.getId()).isEqualTo(sourceUserTask.getId());
         assertThat(foundTask.getAssignee()).isEqualTo(sourceUserTask.getAssignee());
         assertThat(foundTask.getAssignee()).isEqualTo("admin");
+    }
+
+    @Test
+    @DisplayName("EngineConnectionFailedException thrown when set task assignee if engine is not available")
+    void givenActiveTaskAndNotAvailableEngine_whenSetAsignee_thenExceptionThrown() {
+        //given
+        applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testUserTaskWithAssignee.bpmn")
+                .startByKey("userTaskWithAssignee");
+
+        RuntimeUserTaskDto sourceUserTask = camundaRestTestHelper.findRuntimeUserTasksByProcessKey(camunda7, "userTaskWithAssignee").get(0);
+
+        camunda7.stop();
+
+        //when and then
+        assertThatThrownBy(() -> userTaskService.setAssignee(sourceUserTask.getId(), "admin"))
+                .isInstanceOf(EngineConnectionFailedException.class);
     }
 }


### PR DESCRIPTION
1. Adds async data loading for the list views:
   - ProcessDefinitionListView
   - ProcessInstanceListView
   - IncidentDataListView
   - AllTasksView
   - DeploymentListView
   - DecisionDefinitionListView

    It means, each action triggers data loading -> loading state is shown in the data grid -> data or error should be shown in the data grid after loading is completed.
2. Add a default empty state component for all data grids (including Jmix add-ons views) if no data is the data grid is shown.
3. If the selected engine is not available or in the debug state, when trying to open a view by URL, the dialog with Retry and Close actions is opened.
   - Retry action reloads the page.
    - Close action navigates to Dashboard
4. If some action that executes a request to the selected BPM engine (e.g., deploy, start, get total count of items, etc.) fails because of a connection error, then the notification is shown.
5. Add auto-tests for cases when the selected BPM engine is not available.