### PR TITLE
Add "Skip custom listener" and "Skip IO mappings" when terminating process instance #148

### DIFF
--- a/src/main/java/io/flowset/control/service/processinstance/ProcessInstanceBulkTerminateContext.java
+++ b/src/main/java/io/flowset/control/service/processinstance/ProcessInstanceBulkTerminateContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.service.processinstance;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+/**
+ * Context for bulk terminating process instances.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+public class ProcessInstanceBulkTerminateContext {
+    protected List<String> processInstanceIds;
+    protected String reason;
+    protected Boolean skipCustomListeners;
+    protected Boolean skipSubprocesses;
+    protected Boolean skipIoMappings;
+
+    public ProcessInstanceBulkTerminateContext(List<String> processInstanceIds) {
+        this.processInstanceIds = processInstanceIds;
+    }
+}

--- a/src/main/java/io/flowset/control/service/processinstance/ProcessInstanceService.java
+++ b/src/main/java/io/flowset/control/service/processinstance/ProcessInstanceService.java
@@ -93,12 +93,11 @@ public interface ProcessInstanceService {
     void terminateById(String processInstanceId);
 
     /**
-     * Asynchronously terminates process instances with the specified identifiers.
+     * Asynchronously terminates process instances with the specified context.
      *
-     * @param processInstanceIds a list of process instance identifiers
-     * @param reason             a reason to terminate
+     * @param context a context containing data like process instance identifiers
      */
-    void terminateByIdsAsync(List<String> processInstanceIds, @Nullable String reason);
+    void terminateByIdsAsync(ProcessInstanceBulkTerminateContext context);
 
     /**
      * Activates asynchronously the process instances with the specified identifiers.

--- a/src/main/java/io/flowset/control/view/processinstanceterminate/ProcessInstanceTerminateView.java
+++ b/src/main/java/io/flowset/control/view/processinstanceterminate/ProcessInstanceTerminateView.java
@@ -2,6 +2,8 @@ package io.flowset.control.view.processinstanceterminate;
 
 
 import com.vaadin.flow.router.Route;
+import io.flowset.control.service.processinstance.ProcessInstanceBulkTerminateContext;
+import io.jmix.flowui.component.checkbox.JmixCheckbox;
 import io.jmix.flowui.component.textarea.JmixTextArea;
 import io.jmix.flowui.kit.action.ActionPerformedEvent;
 import io.jmix.flowui.view.*;
@@ -20,7 +22,13 @@ public class ProcessInstanceTerminateView extends StandardView {
     private ProcessInstanceService processInstanceService;
 
     @ViewComponent
-    private JmixTextArea reasonTextArea;
+    protected JmixTextArea reasonTextArea;
+    @ViewComponent
+    protected JmixCheckbox skipIoMappingsField;
+    @ViewComponent
+    protected JmixCheckbox skipCustomListenersField;
+    @ViewComponent
+    protected JmixCheckbox skipSubprocessesField;
 
     protected ProcessInstanceData processInstanceData;
 
@@ -28,12 +36,24 @@ public class ProcessInstanceTerminateView extends StandardView {
         this.processInstanceData = processInstanceData;
     }
 
+    @Subscribe
+    public void onBeforeShow(final BeforeShowEvent event) {
+        skipIoMappingsField.setValue(true);
+        skipCustomListenersField.setValue(true);
+    }
+
     @Subscribe("terminateAction")
     public void onTerminateAction(final ActionPerformedEvent event) {
         String processInstanceId = processInstanceData.getId();
         String reasonValue = reasonTextArea.getValue();
 
-        processInstanceService.terminateByIdsAsync(Collections.singletonList(processInstanceId), reasonValue);
+        ProcessInstanceBulkTerminateContext context = new ProcessInstanceBulkTerminateContext(Collections.singletonList(processInstanceId))
+                .setReason(reasonValue)
+                .setSkipCustomListeners(skipCustomListenersField.getValue())
+                .setSkipIoMappings(skipIoMappingsField.getValue())
+                .setSkipSubprocesses(skipSubprocessesField.getValue());
+
+        processInstanceService.terminateByIdsAsync(context);
 
         close(StandardOutcome.SAVE);
     }

--- a/src/main/resources/io/flowset/control/messages_de.properties
+++ b/src/main/resources/io/flowset/control/messages_de.properties
@@ -577,6 +577,12 @@ io.flowset.control.view.processinstance/processDefinition=Prozess
 io.flowset.control.view.processinstance/processInstanceDetailView.baseTitle=Prozessinstanz
 io.flowset.control.view.processinstance/processInstanceDetailView.title=Prozessinstanz "%s"
 io.flowset.control.view.processinstance/runtimeTabCaption=Laufzeit
+io.flowset.control.view.processinstance/skipCustomListenersField.label=Ohne benutzerdefinierte Listener
+io.flowset.control.view.processinstance/skipCustomListenersField.tooltipText=Wenn aktiviert, werden nur integrierte Listener über das Endereignis benachrichtigt
+io.flowset.control.view.processinstance/skipIoMappingsField.label=Ohne Variablemappings
+io.flowset.control.view.processinstance/skipIoMappingsField.tooltipText=Wenn aktiviert, wird die Ausführung der Eingabe-/Ausgabe-Variablemappings übersprungen
+io.flowset.control.view.processinstance/skipSubprocessField.tooltipText=Wenn aktiviert, werden mit der beendeten Prozessinstanz verbundene Teilprozesse nicht beendet
+io.flowset.control.view.processinstance/skipSubprocessesFieldLabel=Keine Teilprozesse
 
 io.flowset.control.view.processinstance/processInstanceActivated=Prozessinstanz aktiviert
 io.flowset.control.view.processinstance/processInstanceSuspended=Prozessinstanz angehalten

--- a/src/main/resources/io/flowset/control/messages_en.properties
+++ b/src/main/resources/io/flowset/control/messages_en.properties
@@ -589,6 +589,12 @@ io.flowset.control.view.processinstance/processDefinition=Process
 io.flowset.control.view.processinstance/processInstanceDetailView.baseTitle=Process instance
 io.flowset.control.view.processinstance/processInstanceDetailView.title=Process instance "%s"
 io.flowset.control.view.processinstance/runtimeTabCaption=Runtime
+io.flowset.control.view.processinstance/skipCustomListenersField.label=Skip custom listeners
+io.flowset.control.view.processinstance/skipCustomListenersField.tooltipText=If enabled, only built in listeners will be notified with the end event
+io.flowset.control.view.processinstance/skipIoMappingsField.label=Skip I/O mappings
+io.flowset.control.view.processinstance/skipIoMappingsField.tooltipText=If enabled, execution of input/output variable mappings will be skipped
+io.flowset.control.view.processinstance/skipSubprocessField.tooltipText=If enabled, subprocesses related to the terminated process instance will not be terminated
+io.flowset.control.view.processinstance/skipSubprocessesFieldLabel=Skip subprocesses
 
 io.flowset.control.view.processinstance/activateDialog.header=Activate process instance
 io.flowset.control.view.processinstance/activateDialog.text=Are you sure you want to activate this process instance?

--- a/src/main/resources/io/flowset/control/messages_es.properties
+++ b/src/main/resources/io/flowset/control/messages_es.properties
@@ -579,6 +579,12 @@ io.flowset.control.view.processinstance/processDefinition=Proceso
 io.flowset.control.view.processinstance/processInstanceDetailView.baseTitle=Instancia de proceso
 io.flowset.control.view.processinstance/processInstanceDetailView.title=Instancia de proceso "%s"
 io.flowset.control.view.processinstance/runtimeTabCaption=Ejecución
+io.flowset.control.view.processinstance/skipCustomListenersField.label=Sin listeners personalizados
+io.flowset.control.view.processinstance/skipCustomListenersField.tooltipText=i está habilitado, solo los listeners integrados serán notificados con el evento de finalización
+io.flowset.control.view.processinstance/skipIoMappingsField.label=Sin mapeos de variables
+io.flowset.control.view.processinstance/skipIoMappingsField.tooltipText=Si está habilitado, se omitirá la ejecución de los mapeos de variables de entrada/salida
+io.flowset.control.view.processinstance/skipSubprocessField.tooltipText=Si está habilitado, los subprocesos relacionados con la instancia de proceso terminada no serán terminados
+io.flowset.control.view.processinstance/skipSubprocessesFieldLabel=Omitir subprocesos
 
 io.flowset.control.view.processinstance/processInstanceActivated=Instancia de proceso activada
 

--- a/src/main/resources/io/flowset/control/messages_ru.properties
+++ b/src/main/resources/io/flowset/control/messages_ru.properties
@@ -587,6 +587,12 @@ io.flowset.control.view.processinstance/processDefinition=Процесс
 io.flowset.control.view.processinstance/processInstanceDetailView.baseTitle=Экземпляр процесса
 io.flowset.control.view.processinstance/processInstanceDetailView.title=Экземпляр процесса "%s"
 io.flowset.control.view.processinstance/runtimeTabCaption=Состояние
+io.flowset.control.view.processinstance/skipCustomListenersField.label=Без пользовательских слушателей
+io.flowset.control.view.processinstance/skipCustomListenersField.tooltipText=Если включено, только встроенные слушатели будут уведомлены о событии завершения
+io.flowset.control.view.processinstance/skipIoMappingsField.label=Без сопоставления переменных
+io.flowset.control.view.processinstance/skipIoMappingsField.tooltipText=Если включено, выполнение сопоставлений входных/выходных переменных будет пропущено
+io.flowset.control.view.processinstance/skipSubprocessField.tooltipText=Если включено, подпроцессы, связанные с завершаемым экземпляром процесса, не будут завершены
+io.flowset.control.view.processinstance/skipSubprocessesFieldLabel=Без подпроцессов
 
 io.flowset.control.view.processinstance/suspendDialog.header=Приостановка экземпляра процесса
 io.flowset.control.view.processinstance/suspendDialog.text=Вы уверены, что хотите приостановить данный экземпляр процесса?

--- a/src/main/resources/io/flowset/control/view/processinstance/bulk-terminate-process-instance-view.xml
+++ b/src/main/resources/io/flowset/control/view/processinstance/bulk-terminate-process-instance-view.xml
@@ -8,6 +8,31 @@
       title="msg://bulkDeleteProcessInstanceView.title">
     <layout>
         <span text="msg://bulkDeleteProcessInstanceMsg" width="100%"/>
+        <formLayout width="100%" classNames="pt-m">
+            <responsiveSteps>
+                <responsiveStep minWidth="0" columns="2"/>
+            </responsiveSteps>
+            <hbox padding="false" themeNames="spacing-s"  alignItems="BASELINE">
+                <checkbox id="skipIoMappingsField" label="msg://skipIoMappingsField.label"/>
+                <icon icon="QUESTION_CIRCLE" classNames="text-secondary" size="0.8em">
+                    <tooltip text="msg://skipIoMappingsField.tooltipText"/>
+                </icon>
+            </hbox>
+
+            <hbox padding="false" themeNames="spacing-s" alignItems="BASELINE">
+                <checkbox id="skipCustomListenersField" label="msg://skipCustomListenersField.label"/>
+                <icon icon="QUESTION_CIRCLE" classNames="text-secondary" size="0.8em">
+                    <tooltip text="msg://skipCustomListenersField.tooltipText"/>
+                </icon>
+            </hbox>
+            <hbox padding="false" themeNames="spacing-s"  alignItems="BASELINE">
+                <checkbox id="skipSubprocessesField" label="msg://skipSubprocessesFieldLabel"/>
+                <icon icon="QUESTION_CIRCLE" classNames="text-secondary" size="0.8em">
+                    <tooltip text="msg://skipSubprocessField.tooltipText"/>
+                </icon>
+            </hbox>
+        </formLayout>
+
         <textArea id="reasonTextArea" clearButtonVisible="true" valueChangeMode="EAGER" themeNames="helper-above-field"
                   minHeight="7em" label="msg://deleteReason" width="100%"/>
 

--- a/src/main/resources/io/flowset/control/view/processinstanceterminate/process-instance-terminate-view.xml
+++ b/src/main/resources/io/flowset/control/view/processinstanceterminate/process-instance-terminate-view.xml
@@ -15,6 +15,30 @@
     <layout>
         <span text="msg://terminateProcessInstanceMsg"
               width="100%"/>
+        <formLayout width="100%" classNames="pt-m">
+            <responsiveSteps>
+                <responsiveStep minWidth="0" columns="2"/>
+            </responsiveSteps>
+            <hbox padding="false" themeNames="spacing-s"  alignItems="BASELINE">
+                <checkbox id="skipIoMappingsField" label="msg://io.flowset.control.view.processinstance/skipIoMappingsField.label"/>
+                <icon icon="QUESTION_CIRCLE" classNames="text-secondary" size="0.8em">
+                    <tooltip text="msg://io.flowset.control.view.processinstance/skipIoMappingsField.tooltipText"/>
+                </icon>
+            </hbox>
+
+            <hbox padding="false" themeNames="spacing-s" alignItems="BASELINE">
+                <checkbox id="skipCustomListenersField" label="msg://io.flowset.control.view.processinstance/skipCustomListenersField.label"/>
+                <icon icon="QUESTION_CIRCLE" classNames="text-secondary" size="0.8em">
+                    <tooltip text="msg://io.flowset.control.view.processinstance/skipCustomListenersField.tooltipText"/>
+                </icon>
+            </hbox>
+            <hbox padding="false" themeNames="spacing-s"  alignItems="BASELINE">
+                <checkbox id="skipSubprocessesField" label="msg://io.flowset.control.view.processinstance/skipSubprocessesFieldLabel"/>
+                <icon icon="QUESTION_CIRCLE" classNames="text-secondary" size="0.8em">
+                    <tooltip text="msg://io.flowset.control.view.processinstance/skipSubprocessField.tooltipText"/>
+                </icon>
+            </hbox>
+        </formLayout>
         <textArea id="reasonTextArea" clearButtonVisible="true" valueChangeMode="EAGER" themeNames="helper-above-field"
                   minHeight="7em" label="msg://deleteReason" width="100%"/>
         <hbox id="actionsPanel" justifyContent="END" width="100%">

--- a/src/test/java/io/flowset/control/test_support/camunda7/CamundaRestTestHelper.java
+++ b/src/test/java/io/flowset/control/test_support/camunda7/CamundaRestTestHelper.java
@@ -219,6 +219,11 @@ public class CamundaRestTestHelper {
         return restHelper.getList(camunda, "/history/process-instance?processDefinitionId=" + processId, HistoricProcessInstanceDto.class);
     }
 
+    @Nullable
+    public List<ProcessInstanceDto> findRuntimeSubprocessInstances(Camunda7Container<?> camunda, String parentProcessInstanceId) {
+        return restHelper.getList(camunda, "/process-instance?superProcessInstanceId=" + parentProcessInstanceId, ProcessInstanceDto.class);
+    }
+
     public List<HistoricDetailDto> getVariableLog(Camunda7Container<?> camunda, String processInstanceId) {
         return restHelper.getList(camunda, "/history/detail?variableUpdates=true&excludeTaskDetails=true&processInstanceId=" + processInstanceId, HistoricDetailDto.class);
     }

--- a/src/test/resources/test_support/terminateinstance/testSkipCustomListeners.bpmn
+++ b/src/test/resources/test_support/terminateinstance/testSkipCustomListeners.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0jp8zws" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0">
+  <bpmn:process id="testSkipCustomListeners" name="testSkipCustomListeners" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0u1lqnh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u1lqnh" sourceRef="StartEvent_1" targetRef="Activity_0oil6si" />
+    <bpmn:serviceTask id="Activity_0oil6si" name="Test external task" camunda:type="external" camunda:topic="test-external-task">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="end">
+          <camunda:script scriptFormat="groovy">execution.setVariable('variableFromListener', 'test')</camunda:script>
+        </camunda:executionListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u1lqnh</bpmn:incoming>
+      <bpmn:outgoing>Flow_02nhjy6</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_17vdhf0">
+      <bpmn:incoming>Flow_02nhjy6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_02nhjy6" sourceRef="Activity_0oil6si" targetRef="Event_17vdhf0" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testSkipCustomListeners">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1e0nhn0_di" bpmnElement="Activity_0oil6si">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17vdhf0_di" bpmnElement="Event_17vdhf0">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u1lqnh_di" bpmnElement="Flow_0u1lqnh">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02nhjy6_di" bpmnElement="Flow_02nhjy6">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/test_support/terminateinstance/testSkipIoMapping.bpmn
+++ b/src/test/resources/test_support/terminateinstance/testSkipIoMapping.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14ojrry" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0">
+  <bpmn:process id="testSkipIoMapping" name="testSkipIoMapping" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0uyime9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0uyime9" sourceRef="StartEvent_1" targetRef="taskWithOutputMapping" />
+    <bpmn:serviceTask id="taskWithOutputMapping" name="Task with mapping" camunda:type="external" camunda:topic="test-task-with-mapping">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:outputParameter name="variableFromMapping">test</camunda:outputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0uyime9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wot2ff</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1ezj0wb">
+      <bpmn:incoming>Flow_0wot2ff</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0wot2ff" sourceRef="taskWithOutputMapping" targetRef="Event_1ezj0wb" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testSkipIoMapping">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wxrp91_di" bpmnElement="taskWithOutputMapping">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ezj0wb_di" bpmnElement="Event_1ezj0wb">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0uyime9_di" bpmnElement="Flow_0uyime9">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wot2ff_di" bpmnElement="Flow_0wot2ff">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/test_support/terminateinstance/testSkipSubprocess.bpmn
+++ b/src/test/resources/test_support/terminateinstance/testSkipSubprocess.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x0ir51" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0">
+  <bpmn:process id="testSkipSubprocess" name="testSkipSubprocess" isExecutable="true" camunda:historyTimeToLive="180" camunda:isStartableInTasklist="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1hz2wt6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1hz2wt6" sourceRef="StartEvent_1" targetRef="testSubprocessTask" />
+    <bpmn:serviceTask id="testSubprocessTask" name="Test subprocess task" camunda:type="external" camunda:topic="test-subprocess-task">
+      <bpmn:incoming>Flow_1hz2wt6</bpmn:incoming>
+      <bpmn:outgoing>Flow_08uirjz</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_04blwfd">
+      <bpmn:incoming>Flow_08uirjz</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_08uirjz" sourceRef="testSubprocessTask" targetRef="Event_04blwfd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testSkipSubprocess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w1xziy_di" bpmnElement="testSubprocessTask">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04blwfd_di" bpmnElement="Event_04blwfd">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1hz2wt6_di" bpmnElement="Flow_1hz2wt6">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08uirjz_di" bpmnElement="Flow_08uirjz">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/resources/test_support/terminateinstance/testSkipSubprocessMain.bpmn
+++ b/src/test/resources/test_support/terminateinstance/testSkipSubprocessMain.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1mocvdm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.23.0">
+  <bpmn:process id="testSkipSubprocessMain" name="testSkipSubprocessMain" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1633k84</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1633k84" sourceRef="StartEvent_1" targetRef="Activity_1j6knxb" />
+    <bpmn:callActivity id="Activity_1j6knxb" name="Test subprocess" calledElement="testSkipSubprocess">
+      <bpmn:incoming>Flow_1633k84</bpmn:incoming>
+      <bpmn:outgoing>Flow_09gjhy0</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_12o4ltr">
+      <bpmn:incoming>Flow_09gjhy0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_09gjhy0" sourceRef="Activity_1j6knxb" targetRef="Event_12o4ltr" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testSkipSubprocessMain">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0oizdoq_di" bpmnElement="Activity_1j6knxb">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_12o4ltr_di" bpmnElement="Event_12o4ltr">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1633k84_di" bpmnElement="Flow_1633k84">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09gjhy0_di" bpmnElement="Flow_09gjhy0">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Add the following additional options to BulkTerminateProcessInstanceView and ProcessInstanceTerminateView:
 - Skip custom listeners
 - Skip I/O variable mappings
 - Skip subprocesses

These options are included in ProcessInstanceBulkTerminateContext used for terminating process instance(s).