### PR TITLE
Add Called processes and Decisions tabs to process detail view #156

### DIFF
--- a/src/main/java/io/flowset/control/entity/decisiondefinition/DecisionReferenceData.java
+++ b/src/main/java/io/flowset/control/entity/decisiondefinition/DecisionReferenceData.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.entity.decisiondefinition;
+
+import io.flowset.uikit.component.bpmnviewer.model.BusinessRuleTaskData;
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@JmixEntity
+@Getter
+@Setter
+public class DecisionReferenceData extends BusinessRuleTaskData {
+
+    @JmixGeneratedValue
+    @JmixId
+    protected UUID id;
+
+}

--- a/src/main/java/io/flowset/control/entity/processdefinition/CalledProcessReferenceData.java
+++ b/src/main/java/io/flowset/control/entity/processdefinition/CalledProcessReferenceData.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.entity.processdefinition;
+
+import io.flowset.uikit.component.bpmnviewer.model.CallActivityData;
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@JmixEntity
+@Getter
+@Setter
+public class CalledProcessReferenceData extends CallActivityData {
+
+    @JmixGeneratedValue
+    @JmixId
+    protected UUID id;
+}

--- a/src/main/java/io/flowset/control/mapper/ProcessElementMetadataMapper.java
+++ b/src/main/java/io/flowset/control/mapper/ProcessElementMetadataMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.mapper;
+
+import io.flowset.control.entity.processdefinition.CalledProcessReferenceData;
+import io.flowset.control.entity.decisiondefinition.DecisionReferenceData;
+import io.flowset.uikit.component.bpmnviewer.model.BusinessRuleTaskData;
+import io.flowset.uikit.component.bpmnviewer.model.CallActivityData;
+import io.jmix.core.Metadata;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public abstract class ProcessElementMetadataMapper {
+    @Autowired
+    Metadata metadata;
+
+    public abstract List<CalledProcessReferenceData> fromCallActivities(List<CallActivityData> callActivityDataList);
+
+    public abstract List<DecisionReferenceData> fromBusinessRuleTasks(List<BusinessRuleTaskData> decisionReferenceDataList);
+
+    @Mapping(target = "id", ignore = true)
+    public abstract CalledProcessReferenceData fromCallActivity(CallActivityData source);
+
+    @Mapping(target = "id", ignore = true)
+    public abstract DecisionReferenceData fromBusinessRuleTask(BusinessRuleTaskData source);
+
+    CalledProcessReferenceData calledProcessReferenceDataClassFactory() {
+        return metadata.create(CalledProcessReferenceData.class);
+    }
+
+    DecisionReferenceData decisionReferenceDataClassFactory() {
+        return metadata.create(DecisionReferenceData.class);
+    }
+}

--- a/src/main/java/io/flowset/control/uicomponent/viewer/handler/BusinessRuleTaskOverlayClickHandler.java
+++ b/src/main/java/io/flowset/control/uicomponent/viewer/handler/BusinessRuleTaskOverlayClickHandler.java
@@ -12,6 +12,7 @@ import io.flowset.control.entity.filter.DecisionDefinitionFilter;
 import io.flowset.control.entity.processdefinition.ProcessDefinitionData;
 import io.flowset.control.service.decisiondefinition.DecisionDefinitionLoadContext;
 import io.flowset.control.service.decisiondefinition.DecisionDefinitionService;
+import io.flowset.control.view.decisiondefinition.DecisionDefinitionDiagramView;
 import io.flowset.control.view.decisiondefinition.DecisionDefinitionDetailView;
 import io.flowset.uikit.component.bpmnviewer.event.DecisionLinkOverlayClickEvent;
 import io.flowset.uikit.component.bpmnviewer.model.BusinessRuleTaskData;
@@ -68,6 +69,22 @@ public class BusinessRuleTaskOverlayClickHandler {
                         .withBackwardNavigation(true)
                         .navigate();
             }
+        }
+    }
+
+    /**
+     * Opens {@link DecisionDefinitionDiagramView} for the decision called from the specified process and activity.
+     *
+     * @param parentProcess        parent process
+     * @param businessRuleTaskData the data from Business Rule Task element from the parent process
+     */
+    public void handleDecisionPreview(ProcessDefinitionData parentProcess,
+                                      BusinessRuleTaskData businessRuleTaskData) {
+        DecisionDefinitionData decisionDefinition = findDecisionDefinition(businessRuleTaskData, parentProcess);
+        if (decisionDefinition != null) {
+            dialogWindows.view(getCurrentView(), DecisionDefinitionDiagramView.class)
+                    .withViewConfigurer(view -> view.setDecisionDefinition(decisionDefinition))
+                    .open();
         }
     }
 

--- a/src/main/java/io/flowset/control/uicomponent/viewer/handler/CallActivityOverlayClickHandler.java
+++ b/src/main/java/io/flowset/control/uicomponent/viewer/handler/CallActivityOverlayClickHandler.java
@@ -19,6 +19,7 @@ import io.flowset.control.entity.processinstance.ProcessInstanceData;
 import io.flowset.control.service.processdefinition.ProcessDefinitionLoadContext;
 import io.flowset.control.service.processdefinition.ProcessDefinitionService;
 import io.flowset.control.view.processdefinition.ProcessDefinitionDetailView;
+import io.flowset.control.view.processdefinition.ProcessDefinitionDiagramView;
 import io.flowset.control.view.processinstance.CalledProcessInstanceDataListView;
 import io.flowset.control.view.processinstance.ProcessInstanceDetailView;
 import io.flowset.uikit.component.bpmnviewer.model.CallActivityData;
@@ -70,6 +71,22 @@ public class CallActivityOverlayClickHandler {
                         .withBackwardNavigation(true)
                         .navigate();
             }
+        }
+    }
+
+    /**
+     * Opens {@link ProcessDefinitionDiagramView} for the process called from the specified process and activity.
+     *
+     * @param parentProcess    parent process
+     * @param callActivityData the data from Call activity element from the parent process
+     */
+    public void handleProcessPreview(ProcessDefinitionData parentProcess,
+                                     CallActivityData callActivityData) {
+        ProcessDefinitionData calledProcess = findCalledProcess(callActivityData, parentProcess);
+        if (calledProcess != null) {
+            dialogWindows.view(getCurrentView(), ProcessDefinitionDiagramView.class)
+                    .withViewConfigurer(view -> view.setProcessDefinition(calledProcess))
+                    .open();
         }
     }
 

--- a/src/main/java/io/flowset/control/view/decisiondefinition/DecisionDefinitionDiagramView.java
+++ b/src/main/java/io/flowset/control/view/decisiondefinition/DecisionDefinitionDiagramView.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.view.decisiondefinition;
+
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.entity.decisiondefinition.DecisionDefinitionData;
+import io.flowset.control.service.decisiondefinition.DecisionDefinitionService;
+import io.flowset.uikit.fragment.dmnviewer.DmnViewerFragment;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.view.DefaultMainViewParent;
+import io.jmix.flowui.view.DialogMode;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Route(value = "decision-definition-diagram", layout = DefaultMainViewParent.class)
+@ViewController("DecisionDefinitionDiagramView")
+@ViewDescriptor("decision-definition-diagram-view.xml")
+@DialogMode(width = "90%", height = "90%", minWidth = "40em", minHeight = "25em")
+public class DecisionDefinitionDiagramView extends StandardView {
+
+    protected DecisionDefinitionData decisionDefinition;
+    @Autowired
+    protected DecisionDefinitionService decisionDefinitionService;
+    @ViewComponent
+    protected DmnViewerFragment viewerFragment;
+    @ViewComponent
+    protected InstanceContainer<DecisionDefinitionData> decisionDefinitionDc;
+
+    @SuppressWarnings("LombokSetterMayBeUsed")
+    public void setDecisionDefinition(DecisionDefinitionData decisionDefinition) {
+        this.decisionDefinition = decisionDefinition;
+    }
+
+    @Subscribe
+    public void onInit(final InitEvent event) {
+        addClassNames(LumoUtility.Padding.Top.XSMALL, LumoUtility.Padding.Left.LARGE,
+                LumoUtility.Padding.Right.LARGE);
+    }
+
+    @Subscribe
+    public void onBeforeShow(final BeforeShowEvent event) {
+        decisionDefinitionDc.setItem(decisionDefinition);
+
+        String dmnXml = decisionDefinitionService.getDmnXml(decisionDefinition.getDecisionDefinitionId());
+        viewerFragment.initViewer();
+        viewerFragment.setDmnXml(dmnXml, decisionDefinition.getKey());
+    }
+}

--- a/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionDetailView.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionDetailView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Haulmont 2024. All Rights Reserved.
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
  * Use is subject to license terms.
  */
 
@@ -8,6 +8,7 @@ package io.flowset.control.view.processdefinition;
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.SvgIcon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.tabs.Tab;
@@ -15,6 +16,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 import io.flowset.control.exception.EngineConnectionFailedException;
 import io.flowset.control.exception.ViewEngineConnectionFailedException;
+import io.flowset.control.mapper.ProcessElementMetadataMapper;
 import io.jmix.core.LoadContext;
 import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
@@ -31,6 +33,8 @@ import io.flowset.control.entity.activity.ProcessActivityStatistics;
 import io.flowset.control.entity.dashboard.IncidentStatistics;
 import io.flowset.control.entity.filter.ProcessDefinitionFilter;
 import io.flowset.control.entity.filter.ProcessInstanceFilter;
+import io.flowset.control.entity.processdefinition.CalledProcessReferenceData;
+import io.flowset.control.entity.decisiondefinition.DecisionReferenceData;
 import io.flowset.control.entity.processdefinition.ProcessDefinitionData;
 import io.flowset.control.entity.processinstance.RuntimeProcessInstanceData;
 import io.flowset.control.service.activity.ActivityService;
@@ -49,6 +53,7 @@ import io.flowset.uikit.component.bpmnviewer.command.ElementMarkerType;
 import io.flowset.uikit.component.bpmnviewer.command.RemoveMarkerCmd;
 import io.flowset.uikit.component.bpmnviewer.command.SetActivityStatisticsCmd;
 import io.flowset.uikit.component.bpmnviewer.event.ElementClickEvent;
+import io.flowset.uikit.component.bpmnviewer.event.XmlImportCompleteEvent;
 import io.flowset.uikit.fragment.bpmnviewer.BpmnViewerFragment;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -104,6 +109,10 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
     @ViewComponent
     protected CollectionLoader<RuntimeProcessInstanceData> processInstanceDataDl;
     @ViewComponent
+    protected CollectionContainer<CalledProcessReferenceData> calledProcessesDc;
+    @ViewComponent
+    protected CollectionContainer<DecisionReferenceData> decisionsDc;
+    @ViewComponent
     protected InstanceContainer<ProcessInstanceFilter> processInstanceFilterDc;
 
     @ViewComponent
@@ -136,6 +145,12 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
 
     @ViewComponent("tabsheet.bpmnXmlTab")
     protected Tab tabsheetBpmnXmlTab;
+    @ViewComponent("tabsheet.calledProcessesTab")
+    protected Tab tabsheetCalledProcessesTab;
+    @ViewComponent("tabsheet.decisionsTab")
+    protected Tab tabsheetDecisionsTab;
+    @Autowired
+    protected ProcessElementMetadataMapper elementMetadataMapper;
 
     @Subscribe
     public void onInit(final InitEvent event) {
@@ -187,6 +202,11 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
     protected void initTabIcons() {
         tabsheetProcessInstancesTab.addComponentAsFirst(VaadinIcon.TASKS.create());
         tabsheetBpmnXmlTab.addComponentAsFirst(VaadinIcon.FILE_CODE.create());
+        tabsheetCalledProcessesTab.addComponentAsFirst(VaadinIcon.SITEMAP.create());
+
+        SvgIcon decisionIcon = new SvgIcon("icons/table.svg");
+        decisionIcon.addClassNames(LumoUtility.IconSize.MEDIUM, LumoUtility.Padding.XSMALL);
+        tabsheetDecisionsTab.addComponentAsFirst(decisionIcon);
     }
 
 
@@ -274,18 +294,33 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
     protected void initViewer(String bpmnXml) {
         viewerFragment.initViewer(bpmnXml);
         viewerFragment.showCalledProcessOverlays();
-        viewerFragment.addCalledProcessOverlayClickListener(callActivityOverlayClickEvent -> {
-            callActivityClickHandler.handleProcessNavigation(processDefinitionDataDc.getItem(),
-                    callActivityOverlayClickEvent.getCallActivity(),
-                    UiComponentUtils.isComponentAttachedToDialog(this));
-        });
+        viewerFragment.addCalledProcessOverlayClickListener(callActivityOverlayClickEvent ->
+                callActivityClickHandler.handleProcessNavigation(processDefinitionDataDc.getItem(),
+                        callActivityOverlayClickEvent.getCallActivity(),
+                        UiComponentUtils.isComponentAttachedToDialog(this)));
         viewerFragment.showDecisionLinkOverlays();
-        viewerFragment.addDecisionLinkOverlayClickListener(businessRuleTaskOverlayClickEvent -> {
-            businessRuleTaskClickHandler.handleDecisionNavigation(processDefinitionDataDc.getItem(),
-                    businessRuleTaskOverlayClickEvent.getBusinessRuleTask(),
-                    UiComponentUtils.isComponentAttachedToDialog(this));
-        });
+        viewerFragment.addDecisionLinkOverlayClickListener(businessRuleTaskOverlayClickEvent ->
+                businessRuleTaskClickHandler.handleDecisionNavigation(processDefinitionDataDc.getItem(),
+                        businessRuleTaskOverlayClickEvent.getBusinessRuleTask(),
+                        UiComponentUtils.isComponentAttachedToDialog(this)));
+        viewerFragment.addImportCompleteListener(this::handleImportComplete);
         showStatistics();
+    }
+
+    protected void handleImportComplete(XmlImportCompleteEvent event) {
+        updateCalledProcessesAndDecisions(event);
+
+    }
+
+    protected void updateCalledProcessesAndDecisions(XmlImportCompleteEvent event) {
+        List<CalledProcessReferenceData> calledProcesses = elementMetadataMapper.fromCallActivities(event.getCalledProcesses());
+        List<DecisionReferenceData> decisions = elementMetadataMapper.fromBusinessRuleTasks(event.getCalledDecisions());
+
+        calledProcessesDc.setItems(calledProcesses);
+        decisionsDc.setItems(decisions);
+
+        updateCalledProcessesTabCaption(calledProcesses.size());
+        updateDecisionsTabCaption(decisions.size());
     }
 
     protected void showStatistics() {
@@ -350,6 +385,18 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
         tabsheetProcessInstancesTab.addComponentAsFirst(VaadinIcon.TASKS.create());
     }
 
+    protected void updateCalledProcessesTabCaption(long count) {
+        tabsheetCalledProcessesTab.setLabel(messageBundle.formatMessage("calledProcessesTab.label", count));
+        tabsheetCalledProcessesTab.addComponentAsFirst(VaadinIcon.SITEMAP.create());
+    }
+
+    protected void updateDecisionsTabCaption(long count) {
+        tabsheetDecisionsTab.setLabel(messageBundle.formatMessage("decisionsTab.label", count));
+        SvgIcon decisionIcon = new SvgIcon("icons/table.svg");
+        decisionIcon.addClassNames(LumoUtility.IconSize.MEDIUM, LumoUtility.Padding.XSMALL);
+        tabsheetDecisionsTab.addComponentAsFirst(decisionIcon);
+    }
+
     protected void initProcessInstanceFilter() {
         ProcessInstanceFilter processInstanceFilter = metadata.create(ProcessInstanceFilter.class);
         processInstanceFilter.setUnfinished(true);
@@ -377,4 +424,5 @@ public class ProcessDefinitionDetailView extends StandardDetailView<ProcessDefin
         badge.setText(text);
         return badge;
     }
+
 }

--- a/src/main/java/io/flowset/control/view/processdefinition/column/CalledProcessKeyColumnFragment.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/column/CalledProcessKeyColumnFragment.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.view.processdefinition.column;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.icon.SvgIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import io.flowset.control.entity.processdefinition.CalledProcessReferenceData;
+import io.flowset.control.entity.processdefinition.ProcessDefinitionData;
+import io.flowset.control.uicomponent.viewer.handler.CallActivityOverlayClickHandler;
+import io.jmix.flowui.component.UiComponentUtils;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
+import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.ViewComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@FragmentDescriptor("called-process-key-column-fragment.xml")
+@RendererItemContainer("calledProcessReferenceDc")
+public class CalledProcessKeyColumnFragment extends FragmentRenderer<HorizontalLayout, CalledProcessReferenceData> {
+
+    @Autowired
+    protected CallActivityOverlayClickHandler callActivityClickHandler;
+    @ViewComponent
+    protected JmixButton keyBtn;
+    @ViewComponent
+    protected JmixButton previewBtn;
+    @ViewComponent
+    protected InstanceContainer<ProcessDefinitionData> processDefinitionDataDc;
+
+    @Subscribe
+    public void onReady(final ReadyEvent event) {
+        previewBtn.setIcon(new SvgIcon("icons/preview.svg"));
+    }
+
+    @Override
+    public void setItem(CalledProcessReferenceData item) {
+        super.setItem(item);
+
+        keyBtn.setText(item.getCalledElement());
+    }
+
+    @Subscribe(id = "keyBtn", subject = "clickListener")
+    public void onKeyBtnClick(final ClickEvent<JmixButton> event) {
+        callActivityClickHandler.handleProcessNavigation(
+                processDefinitionDataDc.getItem(),
+                item,
+                UiComponentUtils.isComponentAttachedToDialog(this));
+    }
+
+    @Subscribe(id = "previewBtn", subject = "clickListener")
+    public void onPreviewBtnClick(final ClickEvent<JmixButton> event) {
+        callActivityClickHandler.handleProcessPreview(
+                processDefinitionDataDc.getItem(),
+                item);
+    }
+}

--- a/src/main/java/io/flowset/control/view/processdefinition/column/DecisionRefColumnFragment.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/column/DecisionRefColumnFragment.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.view.processdefinition.column;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.icon.SvgIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import io.flowset.control.entity.decisiondefinition.DecisionReferenceData;
+import io.flowset.control.entity.processdefinition.ProcessDefinitionData;
+import io.flowset.control.uicomponent.viewer.handler.BusinessRuleTaskOverlayClickHandler;
+import io.jmix.flowui.component.UiComponentUtils;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.fragmentrenderer.FragmentRenderer;
+import io.jmix.flowui.fragmentrenderer.RendererItemContainer;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.ViewComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@FragmentDescriptor("decision-ref-column-fragment.xml")
+@RendererItemContainer("decisionReferenceDc")
+public class DecisionRefColumnFragment extends FragmentRenderer<HorizontalLayout, DecisionReferenceData> {
+
+    @Autowired
+    protected BusinessRuleTaskOverlayClickHandler businessRuleTaskClickHandler;
+    @ViewComponent
+    protected JmixButton keyBtn;
+    @ViewComponent
+    protected JmixButton previewBtn;
+    @ViewComponent
+    protected InstanceContainer<ProcessDefinitionData> processDefinitionDataDc;
+
+    @Subscribe
+    public void onReady(final ReadyEvent event) {
+        previewBtn.setIcon(new SvgIcon("icons/preview.svg"));
+    }
+
+    @Override
+    public void setItem(DecisionReferenceData item) {
+        super.setItem(item);
+
+        keyBtn.setText(item.getDecisionRef());
+    }
+
+    @Subscribe(id = "keyBtn", subject = "clickListener")
+    public void onKeyBtnClick(final ClickEvent<JmixButton> event) {
+        businessRuleTaskClickHandler.handleDecisionNavigation(
+                processDefinitionDataDc.getItem(),
+                item,
+                UiComponentUtils.isComponentAttachedToDialog(this));
+    }
+
+    @Subscribe(id = "previewBtn", subject = "clickListener")
+    public void onPreviewBtnClick(final ClickEvent<JmixButton> event) {
+        businessRuleTaskClickHandler.handleDecisionPreview(
+                processDefinitionDataDc.getItem(),
+                item);
+    }
+}

--- a/src/main/java/io/flowset/control/view/processdefinition/detail/CalledDecisionsTabFragment.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/detail/CalledDecisionsTabFragment.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.view.processdefinition.detail;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import io.flowset.control.entity.decisiondefinition.DecisionReferenceData;
+import io.jmix.flowui.fragment.Fragment;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.view.Install;
+import io.jmix.flowui.view.Supply;
+import org.apache.commons.lang3.StringUtils;
+
+@FragmentDescriptor("called-decisions-tab-fragment.xml")
+public class CalledDecisionsTabFragment extends Fragment<VerticalLayout> {
+
+    private static final String LATEST_VERSION_BINDING = "latest";
+
+    @Supply(to = "decisionsGrid.binding", subject = "renderer")
+    protected Renderer<DecisionReferenceData> decisionsGridBindingRenderer() {
+        return new TextRenderer<>(decisionReferenceData ->
+                StringUtils.defaultIfEmpty(decisionReferenceData.getBinding(), LATEST_VERSION_BINDING));
+    }
+
+    @Install(to = "decisionsGrid.elementId", subject = "tooltipGenerator")
+    private String decisionsGridElementIdTooltipGenerator(final DecisionReferenceData decisionReferenceData) {
+        return StringUtils.defaultIfEmpty(decisionReferenceData.getElementName(), decisionReferenceData.getElementId());
+    }
+}

--- a/src/main/java/io/flowset/control/view/processdefinition/detail/CalledProcessesTabFragment.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/detail/CalledProcessesTabFragment.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.view.processdefinition.detail;
+
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import io.flowset.control.entity.processdefinition.CalledProcessReferenceData;
+import io.jmix.flowui.fragment.Fragment;
+import io.jmix.flowui.fragment.FragmentDescriptor;
+import io.jmix.flowui.view.Install;
+import io.jmix.flowui.view.Supply;
+import org.apache.commons.lang3.StringUtils;
+
+@FragmentDescriptor("called-processes-tab-fragment.xml")
+public class CalledProcessesTabFragment extends Fragment<VerticalLayout> {
+
+    private static final String LATEST_VERSION_BINDING = "latest";
+
+    @Supply(to = "calledProcessesGrid.binding", subject = "renderer")
+    protected Renderer<CalledProcessReferenceData> calledProcessesGridBindingRenderer() {
+        return new TextRenderer<>(calledProcessReferenceData ->
+                StringUtils.defaultIfEmpty(calledProcessReferenceData.getBinding(), LATEST_VERSION_BINDING));
+    }
+
+    @Install(to = "calledProcessesGrid.elementId", subject = "tooltipGenerator")
+    private String calledProcessesGridElementIdTooltipGenerator(final CalledProcessReferenceData calledProcessReferenceData) {
+        return StringUtils.defaultIfEmpty(calledProcessReferenceData.getElementName(), calledProcessReferenceData.getElementId());
+    }
+}

--- a/src/main/resources/io/flowset/control/messages_de.properties
+++ b/src/main/resources/io/flowset/control/messages_de.properties
@@ -122,7 +122,13 @@ io.flowset.control.entity.processdefinition/ProcessDefinitionData.suspended=Ange
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.tenantId=Mandanten-ID
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.version=Version
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.versionTag=Versionstag
-
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData=Aufgerufene Prozessreferenz
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.id=ID
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.calledElement=Schlüssel
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.elementId=Aktivität
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.binding=Binding
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.version=Version
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.versionTag=Versionstag
 io.flowset.control.entity.processinstance/ProcessInstanceData=Prozessinstanzdaten
 io.flowset.control.entity.processinstance/ProcessInstanceData.businessKey=Geschäftsschlüssel
 io.flowset.control.entity.processinstance/ProcessInstanceData.complete=Abgeschlossen
@@ -286,6 +292,7 @@ io.flowset.control.view.deploymentdata/viewTab.title=Anzeigen
 io.flowset.control.view.deploymentdata/viewTab.source=Rohdaten
 io.flowset.control.view.deploymentdata/viewTab.runningInstances=Laufende Instanzen
 
+io.flowset.control.view.decisiondefinition/decisionDefinitionDiagramView.title=Entscheidungstabelle
 io.flowset.control.view.decisiondefinition/decisionDefinitionListView.title=Entscheidungen
 io.flowset.control.view.decisiondefinition/decisionInstancesTab.label=Entscheidungsinstanzen (%s)
 
@@ -512,6 +519,7 @@ io.flowset.control.view.processdefinition/activateBtn.title=Prozessversion aktiv
 io.flowset.control.view.processdefinition/activateProcessDefinitionMsg=Sind Sie sicher, dass Sie diese Prozessversion aktivieren möchten?
 io.flowset.control.view.processdefinition/bulkActivateProcessDefinitionMsg=Sind Sie sicher, dass Sie die ausgewählten Prozesse aktivieren möchten?
 io.flowset.control.view.processdefinition/allVersions=Alle Versionen
+io.flowset.control.view.processdefinition/binding.header=Bindung
 io.flowset.control.view.processdefinition/allInstances=Alle Instanzen
 io.flowset.control.view.processdefinition/deleteAllVersions.tooltip=Nicht nur die ausgewählten Prozessversionen, sondern auch alle Versionen der ausgewählten Prozesse löschen
 io.flowset.control.view.processdefinition/deleteBtn.title=Prozessversion löschen
@@ -560,6 +568,10 @@ io.flowset.control.view.processdefinition/processInstance.state=Status
 io.flowset.control.view.processdefinition/processInstancesMigrationStarted=Prozessinstanzen-Migration gestartet
 io.flowset.control.view.processdefinition/processInstancesTab.defaultLabel=Prozessinstanzen
 io.flowset.control.view.processdefinition/processInstancesTab.label=Prozessinstanzen (%s)
+io.flowset.control.view.processdefinition/calledProcessesTab.defaultLabel=Aufgerufene Prozesse
+io.flowset.control.view.processdefinition/calledProcessesTab.label=Aufgerufene Prozesse (%s)
+io.flowset.control.view.processdefinition/decisionsTab.defaultLabel=Entscheidungen
+io.flowset.control.view.processdefinition/decisionsTab.label=Entscheidungen (%s)
 io.flowset.control.view.processdefinition/processesDeleted=Prozesse erfolgreich gelöscht
 io.flowset.control.view.processdefinition/selectState=Status auswählen
 io.flowset.control.view.processdefinition/selectedActivityBadge.text=Aktivität: %s
@@ -812,6 +824,13 @@ io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.resourceName
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.tenantId=Mandanten-ID
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.version=Version
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.versionTag=Versionstag
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData=Entscheidungsreferenz
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.binding=Binding
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.decisionRef=Schlüssel
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.elementId=Aktivität
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.id=ID
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.version=Version
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.versionTag=Versionstag
 
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData=Entscheidungseingabeinstanz
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData.clauseName=Name

--- a/src/main/resources/io/flowset/control/messages_en.properties
+++ b/src/main/resources/io/flowset/control/messages_en.properties
@@ -124,7 +124,13 @@ io.flowset.control.entity.processdefinition/ProcessDefinitionData.suspended=Susp
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.tenantId=Tenant Id
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.version=Version
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.versionTag=Version tag
-
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData=Called process reference
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.id=Id
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.calledElement=Key
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.elementId=Activity
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.binding=Binding
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.version=Version
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.versionTag=Version tag
 io.flowset.control.entity.processinstance/ProcessInstanceData=Process instance data
 io.flowset.control.entity.processinstance/ProcessInstanceData.businessKey=Business key
 
@@ -290,7 +296,7 @@ io.flowset.control.view.deploymentdata/viewTab.title=View
 io.flowset.control.view.deploymentdata/viewTab.source=Raw data
 io.flowset.control.view.deploymentdata/viewTab.runningInstances=Running instances
 
-
+io.flowset.control.view.decisiondefinition/decisionDefinitionDiagramView.title=Decision table
 io.flowset.control.view.decisiondefinition/decisionDefinitionListView.title=Decisions
 io.flowset.control.view.decisiondefinition/decisionInstancesTab.label=Decision instances (%s)
 
@@ -570,6 +576,10 @@ io.flowset.control.view.processdefinition/processInstances=Process instances
 io.flowset.control.view.processdefinition/processInstancesMigrationStarted=Process instances migration started
 io.flowset.control.view.processdefinition/processInstancesTab.defaultLabel=Process instances
 io.flowset.control.view.processdefinition/processInstancesTab.label=Process instances (%s)
+io.flowset.control.view.processdefinition/calledProcessesTab.defaultLabel=Called processes
+io.flowset.control.view.processdefinition/calledProcessesTab.label=Called processes (%s)
+io.flowset.control.view.processdefinition/decisionsTab.defaultLabel=Decisions
+io.flowset.control.view.processdefinition/decisionsTab.label=Decisions (%s)
 io.flowset.control.view.processdefinition/processesDeleted=Processes deleted successfully
 io.flowset.control.view.processdefinition/selectState=Select a state
 io.flowset.control.view.processdefinition/selectedActivityBadge.text=Activity: %s
@@ -837,6 +847,13 @@ io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.resourceName
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.tenantId=Tenant id
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.version=Version
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.versionTag=Version tag
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData=Decision reference
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.binding=Binding
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.decisionRef=Key
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.elementId=Activity
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.id=Id
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.version=Version
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.versionTag=Version tag
 
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData=Decision input instance
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData.clauseName=Name

--- a/src/main/resources/io/flowset/control/messages_es.properties
+++ b/src/main/resources/io/flowset/control/messages_es.properties
@@ -123,7 +123,13 @@ io.flowset.control.entity.processdefinition/ProcessDefinitionData.suspended=Susp
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.tenantId=Id de inquilino
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.version=Versión
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.versionTag=Etiqueta de versión
-
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData=Referencia de proceso llamado
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.id=Id
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.calledElement=Clave
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.elementId=Actividad
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.binding=Binding
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.version=Versión
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.versionTag=Etiqueta de versión
 io.flowset.control.entity.processinstance/ProcessInstanceData=Datos de instancia de proceso
 io.flowset.control.entity.processinstance/ProcessInstanceData.businessKey=Clave de negocio
 io.flowset.control.entity.processinstance/ProcessInstanceData.complete=Completado
@@ -303,6 +309,7 @@ io.flowset.control.view.deploymentdata/viewTab.title=Ver
 io.flowset.control.view.deploymentdata/viewTab.source=Datos en bruto
 io.flowset.control.view.deploymentdata/viewTab.runningInstances=Instancias en ejecución
 
+io.flowset.control.view.decisiondefinition/decisionDefinitionDiagramView.title=Tabla de decisiones
 io.flowset.control.view.decisiondefinition/decisionDefinitionListView.title=Decisiones
 io.flowset.control.view.decisiondefinition/decisionInstancesTab.label=Instancias de decisión (%s)
 
@@ -562,6 +569,10 @@ io.flowset.control.view.processdefinition/processInstances=Instancias de proceso
 io.flowset.control.view.processdefinition/processInstancesMigrationStarted=Inicio de migración de instancias de proceso
 io.flowset.control.view.processdefinition/processInstancesTab.defaultLabel=Instancias de proceso
 io.flowset.control.view.processdefinition/processInstancesTab.label=Instancias de proceso (%s)
+io.flowset.control.view.processdefinition/calledProcessesTab.defaultLabel=Procesos llamados
+io.flowset.control.view.processdefinition/calledProcessesTab.label=Procesos llamados (%s)
+io.flowset.control.view.processdefinition/decisionsTab.defaultLabel=Decisiones
+io.flowset.control.view.processdefinition/decisionsTab.label=Decisiones (%s)
 io.flowset.control.view.processdefinition/processesDeleted=Procesos eliminados correctamente
 io.flowset.control.view.processdefinition/selectState=Seleccionar estado
 io.flowset.control.view.processdefinition/selectedActivityBadge.text=Actividad: %s
@@ -815,6 +826,13 @@ io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.resourceName
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.tenantId=Id de inquilino
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.version=Versión
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.versionTag=Etiqueta de versión
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData=Referencia de decisión
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.binding=Binding
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.decisionRef=Clave
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.elementId=Actividad
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.id=Id
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.version=Versión
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.versionTag=Etiqueta de versión
 
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData=Instancia de entrada de decisión
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData.clauseName=Nombre

--- a/src/main/resources/io/flowset/control/messages_ru.properties
+++ b/src/main/resources/io/flowset/control/messages_ru.properties
@@ -117,7 +117,13 @@ io.flowset.control.entity.processdefinition/ProcessDefinitionData.suspended=Susp
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.tenantId=Id тенанта
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.version=Версия
 io.flowset.control.entity.processdefinition/ProcessDefinitionData.versionTag=Тег версии
-
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData=Связанный процесс
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.id=Id
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.calledElement=Ключ
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.elementId=Активность
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.binding=Связывание
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.version=Версия
+io.flowset.control.entity.processdefinition/CalledProcessReferenceData.versionTag=Тег версии
 io.flowset.control.entity.processinstance/ProcessInstanceData=Экземпляр процесса
 io.flowset.control.entity.processinstance/ProcessInstanceData.businessKey=Бизнес ключ
 
@@ -286,7 +292,7 @@ io.flowset.control.view.deploymentdata/viewTab.title=Просмотр
 io.flowset.control.view.deploymentdata/viewTab.source=Исходные данные
 io.flowset.control.view.deploymentdata/viewTab.runningInstances=Запущенные экземпляры
 
-
+io.flowset.control.view.decisiondefinition/decisionDefinitionDiagramView.title=Таблица решений
 io.flowset.control.view.decisiondefinition/decisionDefinitionListView.title=Таблицы решений
 io.flowset.control.view.decisiondefinition/decisionInstancesTab.label=Экземпляры решений (%s)
 
@@ -567,6 +573,10 @@ io.flowset.control.view.processdefinition/processInstances=Экземпляры 
 io.flowset.control.view.processdefinition/processInstancesMigrationStarted=Миграция экземпляров процесса запущена
 io.flowset.control.view.processdefinition/processInstancesTab.defaultLabel=Экземпляры процесса
 io.flowset.control.view.processdefinition/processInstancesTab.label=Экземпляры процесса (%s)
+io.flowset.control.view.processdefinition/calledProcessesTab.defaultLabel=Связанные процессы
+io.flowset.control.view.processdefinition/calledProcessesTab.label=Вызываемые процессы (%s)
+io.flowset.control.view.processdefinition/decisionsTab.defaultLabel=Таблицы решений
+io.flowset.control.view.processdefinition/decisionsTab.label=Таблицы решений (%s)
 io.flowset.control.view.processdefinition/processesDeleted=Процессы успешно удалены
 io.flowset.control.view.processdefinition/selectState=Выберите состояние
 io.flowset.control.view.processdefinition/selectedActivityBadge.text=Активность: %s
@@ -838,6 +848,13 @@ io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.resourceName
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.tenantId=Id тенанта
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.version=Версия
 io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.versionTag=Тэг версии
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData=Связанное решение
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.binding=Связывание
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.decisionRef=Ключ
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.elementId=Активность
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.id=Id
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.version=Версия
+io.flowset.control.entity.decisiondefinition/DecisionReferenceData.versionTag=Тег версии
 
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData=Экземпляр входного параметра
 io.flowset.control.entity.decisioninstance/HistoricDecisionInputInstanceShortData.clauseName=Имя

--- a/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-diagram-view.xml
+++ b/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-diagram-view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2026. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view"
+      title="msg://decisionDefinitionDiagramView.title">
+    <actions>
+        <action id="close" text="msg:///actions.Close" type="view_close"/>
+    </actions>
+    <data>
+        <instance id="decisionDefinitionDc" class="io.flowset.control.entity.decisiondefinition.DecisionDefinitionData"/>
+    </data>
+    <layout>
+        <hbox padding="false" width="50%">
+            <textField id="keyField" classNames="pt-xs" width="100%" maxWidth="20em"
+                       label="msg://io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.key"
+                       dataContainer="decisionDefinitionDc"
+                       property="key" readOnly="true"/>
+            <textField id="versionField" classNames="pt-xs"
+                       dataContainer="decisionDefinitionDc"
+                       label="msg://io.flowset.control.entity.decisiondefinition/DecisionDefinitionData.version"
+                       property="version" readOnly="true"/>
+        </hbox>
+        <fragment id="viewerFragment" class="io.flowset.uikit.fragment.dmnviewer.DmnViewerFragment"/>
+        <hbox width="100%" justifyContent="END">
+            <button id="closeBtn" action="close"/>
+        </hbox>
+    </layout>
+</view>

--- a/src/main/resources/io/flowset/control/view/processdefinition/column/called-process-key-column-fragment.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/column/called-process-key-column-fragment.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2026. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="calledProcessReferenceDc"
+                  class="io.flowset.control.entity.processdefinition.CalledProcessReferenceData"/>
+        <instance id="processDefinitionDataDc"
+                  class="io.flowset.control.entity.processdefinition.ProcessDefinitionData"
+                  provided="true"/>
+    </data>
+    <content>
+        <hbox id="root" padding="false" width="100%" justifyContent="START" themeNames="spacing-s"
+              classNames="overflow-hidden" alignItems="BASELINE">
+            <startSlot>
+                <button id="keyBtn" themeNames="tertiary-inline link" whiteSpace="NOWRAP"
+                        width="auto"
+                        classNames="overflow-hidden text-ellipsis flex-shrink"/>
+            </startSlot>
+            <endSlot>
+                <button id="previewBtn" themeNames="tertiary-inline"/>
+            </endSlot>
+        </hbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/flowset/control/view/processdefinition/column/decision-ref-column-fragment.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/column/decision-ref-column-fragment.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) Haulmont 2026. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="decisionReferenceDc"
+                  class="io.flowset.control.entity.decisiondefinition.DecisionReferenceData"/>
+        <instance id="processDefinitionDataDc"
+                  class="io.flowset.control.entity.processdefinition.ProcessDefinitionData"
+                  provided="true"/>
+    </data>
+    <content>
+        <hbox id="root" padding="false" width="100%" justifyContent="START" themeNames="spacing-s"
+              classNames="overflow-hidden" alignItems="BASELINE">
+            <startSlot>
+                <button id="keyBtn" themeNames="tertiary-inline link" whiteSpace="NOWRAP"
+                        width="auto"
+                        classNames="overflow-hidden text-ellipsis flex-shrink"/>
+            </startSlot>
+            <endSlot>
+                <button id="previewBtn" themeNames="tertiary-inline"/>
+            </endSlot>
+        </hbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/flowset/control/view/processdefinition/detail/called-decisions-tab-fragment.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/detail/called-decisions-tab-fragment.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright (c) Haulmont 2026. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="processDefinitionDataDc"
+                  class="io.flowset.control.entity.processdefinition.ProcessDefinitionData"
+                  provided="true"/>
+        <collection id="decisionsDc"
+                    class="io.flowset.control.entity.decisiondefinition.DecisionReferenceData"
+                    provided="true"/>
+    </data>
+    <content>
+        <vbox id="root" width="100%" height="100%" padding="false">
+            <dataGrid id="decisionsGrid" width="100%" height="100%" themeNames="compact"
+                      dataContainer="decisionsDc">
+                <columns resizable="true">
+                    <column property="decisionRef">
+                        <fragmentRenderer
+                                class="io.flowset.control.view.processdefinition.column.DecisionRefColumnFragment"/>
+                    </column>
+                    <column property="binding" sortable="false"/>
+                    <column property="version" sortable="false"/>
+                    <column property="versionTag" sortable="false"/>
+                    <column property="elementId"/>
+                </columns>
+            </dataGrid>
+        </vbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/flowset/control/view/processdefinition/detail/called-processes-tab-fragment.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/detail/called-processes-tab-fragment.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright (c) Haulmont 2026. All Rights Reserved.
+  ~ Use is subject to license terms.
+  -->
+
+<fragment xmlns="http://jmix.io/schema/flowui/fragment">
+    <data>
+        <instance id="processDefinitionDataDc"
+                  class="io.flowset.control.entity.processdefinition.ProcessDefinitionData"
+                  provided="true"/>
+        <collection id="calledProcessesDc"
+                    class="io.flowset.control.entity.processdefinition.CalledProcessReferenceData"
+                    provided="true"/>
+    </data>
+    <content>
+        <vbox id="root" width="100%" height="100%" padding="false">
+            <dataGrid id="calledProcessesGrid" width="100%" height="100%" themeNames="compact"
+                      dataContainer="calledProcessesDc">
+                <columns resizable="true">
+                    <column property="calledElement" autoWidth="true" flexGrow="1">
+                        <fragmentRenderer
+                                class="io.flowset.control.view.processdefinition.column.CalledProcessKeyColumnFragment"/>
+                    </column>
+                    <column property="binding" sortable="false"/>
+                    <column property="version" sortable="false"/>
+                    <column property="versionTag" sortable="false"/>
+                    <column property="elementId"/>
+                </columns>
+            </dataGrid>
+        </vbox>
+    </content>
+</fragment>

--- a/src/main/resources/io/flowset/control/view/processdefinition/process-definition-detail-view.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/process-definition-detail-view.xml
@@ -14,6 +14,10 @@
                     class="io.flowset.control.entity.processinstance.RuntimeProcessInstanceData">
             <loader id="processInstanceDataDl"/>
         </collection>
+        <collection id="calledProcessesDc"
+                    class="io.flowset.control.entity.processdefinition.CalledProcessReferenceData"/>
+        <collection id="decisionsDc"
+                    class="io.flowset.control.entity.decisiondefinition.DecisionReferenceData"/>
         <instance id="processInstanceFilterDc" class="io.flowset.control.entity.filter.ProcessInstanceFilter">
             <loader id="processInstanceFilterDl"/>
             <fetchPlan extends="_base"/>
@@ -58,6 +62,14 @@
                         <tab id="bpmnXmlTab" label="msg://bpmnXmlTab" enabled="true">
                             <codeEditor mode="XML" readOnly="true" id="bpmnXmlEditor" width="100%" height="100%"
                                         css="padding:0"/>
+                        </tab>
+                        <tab id="calledProcessesTab" label="msg://calledProcessesTab.defaultLabel">
+                            <fragment id="calledProcessesFragment"
+                                      class="io.flowset.control.view.processdefinition.CalledProcessesTabFragment"/>
+                        </tab>
+                        <tab id="decisionsTab" label="msg://decisionsTab.defaultLabel">
+                            <fragment id="decisionsFragment"
+                                      class="io.flowset.control.view.processdefinition.CalledDecisionsTabFragment"/>
                         </tab>
                     </tabSheet>
                 </div>

--- a/src/main/resources/io/flowset/control/view/processdefinition/process-definition-detail-view.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/process-definition-detail-view.xml
@@ -66,11 +66,11 @@
                         </tab>
                         <tab id="calledProcessesTab" label="msg://calledProcessesTab.defaultLabel">
                             <fragment id="calledProcessesFragment"
-                                      class="io.flowset.control.view.processdefinition.CalledProcessesTabFragment"/>
+                                      class="io.flowset.control.view.processdefinition.detail.CalledProcessesTabFragment"/>
                         </tab>
                         <tab id="decisionsTab" label="msg://decisionsTab.defaultLabel">
                             <fragment id="decisionsFragment"
-                                      class="io.flowset.control.view.processdefinition.CalledDecisionsTabFragment"/>
+                                      class="io.flowset.control.view.processdefinition.detail.CalledDecisionsTabFragment"/>
                         </tab>
                     </tabSheet>
                 </div>


### PR DESCRIPTION
1. Add CalledProcessesTabFragment - content of the Called processes tab in ProcessDefinitionDetailView Shows a data grid with called processes that are collected from Call activity elements from the BPMN diagram. Displayed columns: Key, Binding, Version, Version tag and Activity.
2. Add CalledDecisionsTabFragment - a content of the Decisions tab in ProcessDefinitionDetailView. Shows a data grid with called processes that are collected from Business Rule Task elements from the BPMN diagram. Displayed columns: Key, Binding, Version, Version tag and Activity.