### PR TITLE
Export List Data to Excel #246

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,9 @@ dependencies {
     //Vaadin add-ons
     implementation "org.vaadin.addons.componentfactory:spinner"
 
+    // Apache POI
+    implementation 'org.apache.poi:poi-ooxml'
+
     // Spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation "org.springframework.cloud:spring-cloud-dependencies"

--- a/src/main/java/io/flowset/control/action/ControlExcelExportAction.java
+++ b/src/main/java/io/flowset/control/action/ControlExcelExportAction.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.action;
+
+import io.flowset.control.export.ControlExcelExporter;
+import io.jmix.core.TimeSource;
+import io.jmix.core.metamodel.datatype.DatatypeFormatter;
+import io.jmix.flowui.action.ActionType;
+import io.jmix.gridexportflowui.action.ExcelExportAction;
+import io.jmix.gridexportflowui.action.ExportAction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static io.jmix.flowui.component.UiComponentUtils.getCurrentView;
+
+/**
+ * Extends {@link ExcelExportAction} with extended functionality for exporting data to Excel format.
+ * For example, it allows using view name and current time as a file name.
+ */
+@ActionType(ControlExcelExportAction.ID)
+public class ControlExcelExportAction extends ExcelExportAction {
+    public static final String ID = "control_excelExport";
+
+    protected boolean useViewNameAsFileName = true;
+
+    protected TimeSource timeSource;
+    protected DatatypeFormatter datatypeFormatter;
+
+    public ControlExcelExportAction() {
+        this(ID);
+    }
+
+    public ControlExcelExportAction(String id) {
+        super(id);
+    }
+
+    public boolean isUseViewNameAsFileName() {
+        return useViewNameAsFileName;
+    }
+
+    public void setUseViewNameAsFileName(boolean useViewNameAsFileName) {
+        this.useViewNameAsFileName = useViewNameAsFileName;
+    }
+
+    @Autowired
+    public void setTimeSource(TimeSource timeSource) {
+        this.timeSource = timeSource;
+    }
+    
+    @Autowired
+    public void setDatatypeFormatter(DatatypeFormatter datatypeFormatter) {
+        this.datatypeFormatter = datatypeFormatter;
+    }
+
+    @Override
+    public void execute() {
+        if (useViewNameAsFileName) {
+            String pageTitle = getCurrentView().getPageTitle().toLowerCase();
+            String currentDateTimeFormatted =  datatypeFormatter.formatDateTime(timeSource.currentTimestamp())
+                    .replaceAll("[^a-zA-Z0-9.-]", "_");
+
+            String fileName = "%s_%s".formatted(pageTitle.toLowerCase(), currentDateTimeFormatted);
+
+            dataGridExporter.setFileName(fileName);
+        }
+        super.execute();
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        super.setApplicationContext(applicationContext);
+        withExporter(ControlExcelExporter.class);
+    }
+
+    protected String getMessage(String id) {
+        return messages.getMessage(ExportAction.class, id);
+    }
+
+}

--- a/src/main/java/io/flowset/control/entity/batch/BatchStatisticsData.java
+++ b/src/main/java/io/flowset/control/entity/batch/BatchStatisticsData.java
@@ -20,4 +20,23 @@ public class BatchStatisticsData extends RuntimeBatchData {
     public boolean isFailed() {
         return failedJobs != null && failedJobs > 0;
     }
+
+    /**
+     * Calculates the progress of the batch execution in percentage.
+     *
+     * @return progress of batch execution in percents
+     */
+    public int getProgressPercent() {
+        int totalJobs = this.totalJobs != null && this.totalJobs > 0 ? this.totalJobs : 0;
+        int completedJobs = this.completedJobs != null ? this.completedJobs : 0;
+
+        int percent;
+        if (totalJobs == 0) {
+            percent = 0;
+        } else {
+            double ratio = completedJobs / (double) totalJobs;
+            percent = (int) Math.round(ratio * 100);
+        }
+        return percent;
+    }
 }

--- a/src/main/java/io/flowset/control/export/ControlExcelExporter.java
+++ b/src/main/java/io/flowset/control/export/ControlExcelExporter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Haulmont 2026. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package io.flowset.control.export;
+
+import io.jmix.core.DateTimeTransformations;
+import io.jmix.core.security.CurrentAuthentication;
+import io.jmix.flowui.Notifications;
+import io.jmix.gridexportflowui.GridExportProperties;
+import io.jmix.gridexportflowui.exporter.entitiesloader.AllEntitiesLoaderFactory;
+import io.jmix.gridexportflowui.exporter.excel.ExcelExporter;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component("control_ExcelExporter")
+@Scope(BeanDefinition.SCOPE_PROTOTYPE)
+public class ControlExcelExporter extends ExcelExporter {
+
+    public ControlExcelExporter(GridExportProperties gridExportProperties,
+                                Notifications notifications, AllEntitiesLoaderFactory allEntitiesLoaderFactory,
+                                CurrentAuthentication currentAuthentication,
+                                DateTimeTransformations dateTimeTransformations) {
+        super(gridExportProperties, notifications, allEntitiesLoaderFactory, currentAuthentication, dateTimeTransformations);
+    }
+
+    @Override
+    protected void createWorkbookWithSheet() {
+        if (gridExportProperties.getExcel().isUseSxssf()) {
+            // A shared strings table is required to keep the bold font of header cells: without it
+            // SXSSF writes string cells as inline strings and drops rich text formatting runs.
+            wb = new SXSSFWorkbook(null, SXSSFWorkbook.DEFAULT_WINDOW_SIZE, false, true);
+        } else {
+            wb = new XSSFWorkbook();
+        }
+
+        sheet = wb.createSheet("Export");
+    }
+}

--- a/src/main/java/io/flowset/control/view/alltasks/AllTasksView.java
+++ b/src/main/java/io/flowset/control/view/alltasks/AllTasksView.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.action.ControlExcelExportAction;
 import io.flowset.control.action.usertask.BulkCompleteUserTaskAction;
 import io.flowset.control.action.usertask.BulkReassignTaskAction;
 import io.flowset.control.facet.urlqueryparameters.AllUserTaskListQueryParamBinder;
@@ -129,6 +130,8 @@ public class AllTasksView extends AbstractListViewWithDelayedLoad<UserTaskData> 
     protected UrlQueryParametersFacet urlQueryParameters;
     @Autowired
     protected Fragments fragments;
+    @ViewComponent("tasksDataGrid.excelExport")
+    protected ControlExcelExportAction excelExportAction;
 
     protected Map<String, ProcessDefinitionData> processDefinitionsMap = new HashMap<>();
     protected AllUserTaskListQueryParamBinder queryParamBinder;
@@ -160,6 +163,13 @@ public class AllTasksView extends AbstractListViewWithDelayedLoad<UserTaskData> 
     protected void initActions() {
         completeTaskAction.setAfterSaveHandler(this::startLoadData);
         reassignTaskAction.setAfterSaveHandler(this::startLoadData);
+        excelExportAction.addColumnValueProvider("processDefinitionId", context -> {
+            UserTaskData entity = context.getEntity();
+            String processDefinitionId = entity.getProcessDefinitionId();
+            ProcessDefinitionData processDefinition = processDefinitionsMap.get(processDefinitionId);
+
+            return processDefinition != null ? componentHelper.getProcessLabel(processDefinition) : processDefinitionId;
+        });
     }
 
     @Install(to = "processDefinitionLookup", subject = "itemsFetchCallback")

--- a/src/main/java/io/flowset/control/view/batch/AllBatchListView.java
+++ b/src/main/java/io/flowset/control/view/batch/AllBatchListView.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.data.event.SortEvent;
 import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.action.ControlExcelExportAction;
 import io.flowset.control.entity.batch.BatchData;
 import io.flowset.control.entity.batch.BatchStatisticsData;
 import io.flowset.control.entity.filter.BatchFilter;
@@ -26,6 +27,7 @@ import io.flowset.control.view.batch.filter.*;
 import io.jmix.core.DataLoadContext;
 import io.jmix.core.LoadContext;
 import io.jmix.core.Metadata;
+import io.jmix.core.metamodel.datatype.DatatypeFormatter;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.ViewNavigators;
 import io.jmix.flowui.component.UiComponentUtils;
@@ -66,6 +68,9 @@ public class AllBatchListView extends AbstractListViewWithDelayedLoad<BatchStati
     @Autowired
     protected UiComponents uiComponents;
     @Autowired
+    protected DatatypeFormatter datatypeFormatter;
+
+    @Autowired
     protected ApplicationContext applicationContext;
 
     @ViewComponent
@@ -74,6 +79,9 @@ public class AllBatchListView extends AbstractListViewWithDelayedLoad<BatchStati
     protected InstanceContainer<BatchFilter> activeBatchFilterDc;
     @ViewComponent
     protected DataGrid<BatchStatisticsData> activeBatchesDataGrid;
+
+    @ViewComponent("activeBatchesDataGrid.excelExport")
+    protected ControlExcelExportAction excelExportAction;
 
     @ViewComponent
     protected CollectionLoader<BatchData> completedBatchesDl;
@@ -111,7 +119,10 @@ public class AllBatchListView extends AbstractListViewWithDelayedLoad<BatchStati
         componentHelper.addNoDataGridStateComponents(completedBatchGridEmptyStateBox);
 
         setDefaultSort();
+        initActions();
     }
+
+
 
     @Subscribe
     public void onReady(final ReadyEvent event) {
@@ -142,6 +153,14 @@ public class AllBatchListView extends AbstractListViewWithDelayedLoad<BatchStati
 
         completedBatchesDataGrid.sort(Collections.singletonList(new GridSortOrder<>(
                 completedBatchesDataGrid.getColumnByKey("startTime"), SortDirection.DESCENDING)));
+    }
+
+    protected void initActions() {
+        excelExportAction.addColumnValueProvider("progress", context -> {
+            BatchStatisticsData entity = context.getEntity();
+            int percent = entity.getProgressPercent();
+            return datatypeFormatter.formatInteger(percent) + "%";
+        });
     }
 
     @Install(to = "activeBatchesDl", target = Target.DATA_LOADER)

--- a/src/main/java/io/flowset/control/view/batch/column/BatchProgressColumnFragment.java
+++ b/src/main/java/io/flowset/control/view/batch/column/BatchProgressColumnFragment.java
@@ -32,16 +32,7 @@ public class BatchProgressColumnFragment extends FragmentRenderer<Div, BatchStat
     public void setItem(BatchStatisticsData item) {
         super.setItem(item);
 
-        int totalJobs = item.getTotalJobs() != null && item.getTotalJobs() > 0 ? item.getTotalJobs() : 0;
-        int completedJobs = item.getCompletedJobs() != null ? item.getCompletedJobs() : 0;
-
-        int percent;
-        if (totalJobs == 0) {
-            percent = 0;
-        } else {
-            double ratio = completedJobs / (double) totalJobs;
-            percent = (int) Math.round(ratio * 100);
-        }
+        int percent = item.getProgressPercent();
         progressLabel.setText(datatypeFormatter.formatInteger(percent) + "%");
         progressBar.setValue(percent);
     }

--- a/src/main/java/io/flowset/control/view/decisioninstance/DecisionInstanceDataListView.java
+++ b/src/main/java/io/flowset/control/view/decisioninstance/DecisionInstanceDataListView.java
@@ -10,6 +10,7 @@ import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
+import io.flowset.control.action.ControlExcelExportAction;
 import io.flowset.control.entity.decisiondefinition.DecisionDefinitionData;
 import io.flowset.control.entity.decisioninstance.HistoricDecisionInstanceShortData;
 import io.flowset.control.entity.filter.DecisionInstanceFilter;
@@ -70,6 +71,8 @@ public class DecisionInstanceDataListView extends AbstractListViewWithDelayedLoa
     protected CollectionLoader<HistoricDecisionInstanceShortData> decisionInstancesDl;
     @ViewComponent
     protected InstanceContainer<DecisionInstanceFilter> decisionFilterDc;
+    @ViewComponent("decisionInstancesDataGrid.excelExport")
+    protected ControlExcelExportAction excelExportAction;
 
     @ViewComponent
     protected DataGrid<HistoricDecisionInstanceShortData> decisionInstancesDataGrid;
@@ -83,7 +86,26 @@ public class DecisionInstanceDataListView extends AbstractListViewWithDelayedLoa
         initFilter();
         setDefaultSort();
         initDataGridHeaderRow();
+        initActions();
         urlQueryParameters.registerBinder(new DecisionInstanceListQueryParamBinder(decisionInstancesDataGrid, this::startLoadData));
+    }
+
+    protected void initActions() {
+        excelExportAction.addColumnValueProvider("decisionDefinitionId", context -> {
+            HistoricDecisionInstanceShortData entity = context.getEntity();
+            String decisionDefinitionId = entity.getDecisionDefinitionId();
+            DecisionDefinitionData decisionDefinition = decisionDefinitionsMap.get(decisionDefinitionId);
+
+            return decisionDefinition != null ? componentHelper.getDecisionLabel(decisionDefinition) : decisionDefinitionId;
+        });
+
+        excelExportAction.addColumnValueProvider("processDefinitionId", context -> {
+            HistoricDecisionInstanceShortData entity = context.getEntity();
+            String processDefinitionId = entity.getProcessDefinitionId();
+            ProcessDefinitionData processDefinition = processDefinitionsMap.get(processDefinitionId);
+
+            return processDefinition != null ? componentHelper.getProcessLabel(processDefinition) : processDefinitionId;
+        });
     }
 
     @Supply(to = "decisionInstancesDataGrid.decisionDefinitionId", subject = "renderer")

--- a/src/main/java/io/flowset/control/view/incidentdata/IncidentDataListView.java
+++ b/src/main/java/io/flowset/control/view/incidentdata/IncidentDataListView.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.action.ControlExcelExportAction;
 import io.flowset.control.action.incident.BulkRetryIncidentAction;
 import io.flowset.control.action.incident.RetryIncidentAction;
 import io.flowset.control.facet.urlqueryparameters.IncidentListQueryParamBinder;
@@ -92,17 +93,21 @@ public class IncidentDataListView extends AbstractListViewWithDelayedLoad<Incide
     protected DataGrid<IncidentData> incidentsDataGrid;
     @ViewComponent("incidentsDataGrid.bulkRetry")
     protected BulkRetryIncidentAction bulkRetryAction;
+    @ViewComponent("incidentsDataGrid.excelExport")
+    protected ControlExcelExportAction excelExportAction;
 
     @Autowired
     protected Fragments fragments;
 
     protected Map<String, ProcessDefinitionData> processDefinitionsMap = new HashMap<>();
 
+
     @Subscribe
     public void onInit(final InitEvent event) {
         initFilter();
         initDataGridHeaderRow();
-        bulkRetryAction.setAfterSaveHandler(this::startLoadData);
+        initActions();
+
         urlQueryParameters.registerBinder(new IncidentListQueryParamBinder(incidentsDataGrid, this::startLoadData));
     }
 
@@ -211,6 +216,17 @@ public class IncidentDataListView extends AbstractListViewWithDelayedLoad<Incide
     @Override
     protected void loadData() {
         incidentsDl.load();
+    }
+
+    protected void initActions() {
+        bulkRetryAction.setAfterSaveHandler(this::startLoadData);
+        excelExportAction.addColumnValueProvider("processDefinitionId", context -> {
+            IncidentData entity = context.getEntity();
+            String processDefinitionId = entity.getProcessDefinitionId();
+            ProcessDefinitionData processDefinition = processDefinitionsMap.get(processDefinitionId);
+
+            return processDefinition != null ? componentHelper.getProcessLabel(processDefinition) : processDefinitionId;
+        });
     }
 
     protected void loadProcessDefinitions(List<IncidentData> incidents) {

--- a/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionListView.java
+++ b/src/main/java/io/flowset/control/view/processdefinition/ProcessDefinitionListView.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.action.ControlExcelExportAction;
 import io.flowset.control.view.AbstractListViewWithDelayedLoad;
 import io.flowset.control.action.processdefinition.BulkActivateProcessDefinitionAction;
 import io.flowset.control.action.processdefinition.BulkDeleteProcessDefinitionAction;
@@ -71,6 +72,8 @@ public class ProcessDefinitionListView extends AbstractListViewWithDelayedLoad<P
     protected BulkDeleteProcessDefinitionAction bulkRemove;
     @ViewComponent("processDefinitionsGrid.bulkSuspend")
     protected BulkSuspendProcessDefinitionAction bulkSuspend;
+    @ViewComponent("processDefinitionsGrid.excelExport")
+    protected ControlExcelExportAction excelExportAction;
 
     @Autowired
     protected ProcessDefinitionService processDefinitionService;
@@ -213,10 +216,14 @@ public class ProcessDefinitionListView extends AbstractListViewWithDelayedLoad<P
 
     protected void initActions() {
         bulkActivate.setAfterSaveHandler(this::startLoadData);
-
         bulkRemove.setAfterSaveHandler(this::startLoadData);
-
         bulkSuspend.setAfterSaveHandler(this::startLoadData);
+
+        excelExportAction.addColumnValueProvider("suspended", context -> {
+            ProcessDefinitionData entity = context.getEntity();
+
+            return getStateText(BooleanUtils.isTrue(entity.getSuspended()));
+        });
     }
 
     protected Span createStateBadge(ProcessDefinitionData processDefinitionData) {
@@ -228,9 +235,13 @@ public class ProcessDefinitionListView extends AbstractListViewWithDelayedLoad<P
         String themeNames = suspended ? "badge warning pill" : "badge success pill";
         badge.getElement().getThemeList().add(themeNames);
 
-        String messageKey = suspended ? "processDefinitionList.status.suspended" : "processDefinitionList.status.active";
-        badge.setText(messageBundle.getMessage(messageKey));
+        badge.setText(getStateText(suspended));
         return badge;
+    }
+
+    protected String getStateText(boolean suspended) {
+        String messageKey = suspended ? "processDefinitionList.status.suspended" : "processDefinitionList.status.active";
+        return messageBundle.getMessage(messageKey);
     }
 
     @Override

--- a/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceListView.java
+++ b/src/main/java/io/flowset/control/view/processinstance/ProcessInstanceListView.java
@@ -12,6 +12,7 @@ import com.vaadin.flow.data.provider.SortDirection;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.theme.lumo.LumoUtility;
+import io.flowset.control.action.ControlExcelExportAction;
 import io.flowset.control.action.processinstance.BulkActivateProcessInstanceAction;
 import io.flowset.control.action.processinstance.BulkSuspendProcessInstanceAction;
 import io.flowset.control.action.processinstance.BulkTerminateProcessInstanceAction;
@@ -75,6 +76,8 @@ public class ProcessInstanceListView extends AbstractListViewWithDelayedLoad<Pro
     protected BulkSuspendProcessInstanceAction bulkSuspend;
     @ViewComponent("processInstancesGrid.bulkTerminate")
     protected BulkTerminateProcessInstanceAction bulkTerminate;
+    @ViewComponent("processInstancesGrid.excelExport")
+    protected ControlExcelExportAction excelExportAction;
     @ViewComponent
     protected UrlQueryParametersFacet urlQueryParameters;
     @ViewComponent
@@ -95,6 +98,12 @@ public class ProcessInstanceListView extends AbstractListViewWithDelayedLoad<Pro
         bulkActivate.setAfterSaveHandler(this::startLoadData);
         bulkSuspend.setAfterSaveHandler(this::startLoadData);
         bulkTerminate.setAfterSaveHandler(this::startLoadData);
+
+        excelExportAction.addColumnValueProvider("processDefinitionId", context -> {
+            ProcessInstanceData entity = context.getEntity();
+
+            return getProcessDisplayName(entity);
+        });
     }
 
     protected void setDefaultSort() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,7 @@ jmix.ui.component.filter-show-non-jpa-properties=false
 jmix.ui.view-file-extensions=htm, html, jpg, png, jpeg, pdf
 
 jmix.gridexport.default-columns-to-export=ALL_COLUMNS
+jmix.gridexport.default-export-modes=CURRENT_PAGE, SELECTED_ROWS
 
 jmix.core.available-locales = en,de,es,ru
 

--- a/src/main/resources/io/flowset/control/messages_de.properties
+++ b/src/main/resources/io/flowset/control/messages_de.properties
@@ -13,6 +13,7 @@ decisionNotFound.description.invalidVersion=Version (%s) ist keine Zahl
 decisionNotFound.description.version=Version: %s
 decisionNotFound.description.versionTag=Versionskennung: %s
 decisionNotFound.title=Entscheidungstabelle nicht gefunden
+excelExporter.dateTimeFormat=dd.MM.yyyy HH:mm:ss.000
 offsetDateTimeFormat=dd.MM.yyyy HH:mm:ss.SSS Z
 processColumnFilter.processField.label=Verfahren
 processColumnFilter.processField.placeholder=Wählen Sie einen Wert aus

--- a/src/main/resources/io/flowset/control/messages_en.properties
+++ b/src/main/resources/io/flowset/control/messages_en.properties
@@ -13,6 +13,7 @@ decisionNotFound.description.invalidVersion=Version (%s) is not a number
 decisionNotFound.description.version=Version: %s
 decisionNotFound.description.versionTag=Version tag: %s
 decisionNotFound.title=Decision table not found
+excelExporter.dateTimeFormat=dd/MM/yyyy HH:mm:ss.000
 offsetDateTimeFormat=dd/MM/yyyy HH:mm:ss.SSS Z
 
 processColumnFilter.processField.label=Process

--- a/src/main/resources/io/flowset/control/messages_es.properties
+++ b/src/main/resources/io/flowset/control/messages_es.properties
@@ -13,6 +13,7 @@ decisionNotFound.description.invalidVersion=La versión (%s) no es un número
 decisionNotFound.description.version=Versión: %s
 decisionNotFound.description.versionTag=Etiqueta de versión: %s
 decisionNotFound.title=Tabla de decisiones no encontrada
+excelExporter.dateTimeFormat=dd/MM/yyyy HH:mm:ss.000
 offsetDateTimeFormat=dd/MM/yyyy HH:mm:ss.SSS Z
 
 processColumnFilter.processField.label=Proceso

--- a/src/main/resources/io/flowset/control/messages_ru.properties
+++ b/src/main/resources/io/flowset/control/messages_ru.properties
@@ -13,6 +13,7 @@ decisionNotFound.description.invalidVersion=Версия (%s) не являет�
 decisionNotFound.description.version=Версия: %s
 decisionNotFound.description.versionTag=Тег версии: %s
 decisionNotFound.title=Таблица решений не найдена
+excelExporter.dateTimeFormat=dd.MM.yyyy HH:mm:ss.000
 offsetDateTimeFormat=dd.MM.yyyy HH:mm:ss.SSS Z
 
 processColumnFilter.processField.label=Процесс

--- a/src/main/resources/io/flowset/control/view/alltasks/all-tasks-view.xml
+++ b/src/main/resources/io/flowset/control/view/alltasks/all-tasks-view.xml
@@ -82,6 +82,7 @@
                     <button id="refreshBtn" action="tasksDataGrid.refresh" themeNames="primary success"/>
                     <button id="completeTaskBtn" action="tasksDataGrid.completeTask"/>
                     <button id="reassignTaskBtn" action="tasksDataGrid.reassignTask"/>
+                    <button id="excelExportBtn" action="tasksDataGrid.excelExport"/>
                     <simplePagination id="tasksPagination" dataLoader="tasksDl"/>
                 </hbox>
                 <dataGrid id="tasksDataGrid"
@@ -100,6 +101,7 @@
                                 <property name="openMode" value="DIALOG"/>
                             </properties>
                         </action>
+                        <action id="excelExport" type="control_excelExport"/>
                     </actions>
                     <columns resizable="true">
                         <column property="taskId" frozen="true"/>

--- a/src/main/resources/io/flowset/control/view/batch/all-batch-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/batch/all-batch-list-view.xml
@@ -35,10 +35,11 @@
                 <vbox padding="false" width="100%" height="100%">
                     <hbox id="buttonsPanel" classNames="buttons-panel">
                         <button id="refreshBtn" action="activeBatchesDataGrid.refresh" themeNames="primary success"/>
+                        <button id="excelExportBtn" action="activeBatchesDataGrid.excelExport"/>
                         <simplePagination id="batchesPagination" dataLoader="activeBatchesDl"/>
                     </hbox>
 
-                    <dataGrid id="activeBatchesDataGrid"
+                    <dataGrid id="activeBatchesDataGrid" selectionMode="MULTI"
                               dataContainer="activeBatchesDc"
                               width="100%"
                               minHeight="20em">
@@ -49,6 +50,7 @@
                                     <property name="openMode" value="DIALOG"/>
                                 </properties>
                             </action>
+                            <action id="excelExport" type="control_excelExport"/>
                         </actions>
                         <columns resizable="true">
                             <column property="id" autoWidth="true">
@@ -86,10 +88,11 @@
                     <hbox id="completedBatchButtonsPanel" classNames="buttons-panel">
                         <button id="completedBatchRefreshBtn" action="completedBatchesDataGrid.refresh"
                                 themeNames="primary success"/>
+                        <button id="completedBatchExcelExportBtn" action="completedBatchesDataGrid.excelExport"/>
                         <simplePagination id="completedBatchesPagination" dataLoader="completedBatchesDl"/>
                     </hbox>
 
-                    <dataGrid id="completedBatchesDataGrid"
+                    <dataGrid id="completedBatchesDataGrid" selectionMode="MULTI"
                               dataContainer="completedBatchesDc"
                               width="100%"
                               minHeight="20em">
@@ -100,6 +103,7 @@
                                     <property name="openMode" value="DIALOG"/>
                                 </properties>
                             </action>
+                            <action id="excelExport" type="control_excelExport"/>
                         </actions>
                         <columns resizable="true">
                             <column property="id" autoWidth="true">

--- a/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/decisiondefinition/decision-definition-list-view.xml
@@ -54,9 +54,10 @@
         <hbox id="buttonsPanel" classNames="buttons-panel">
             <button id="refreshBtn" action="decisionDefinitionsGrid.refresh" themeNames="primary success"/>
             <button id="deployBtn" action="decisionDefinitionsGrid.deploy"/>
+            <button id="excelExportBtn" action="decisionDefinitionsGrid.excelExport"/>
             <simplePagination id="decisionDefinitionPagination" dataLoader="decisionDefinitionsDl"/>
         </hbox>
-        <dataGrid id="decisionDefinitionsGrid"
+        <dataGrid id="decisionDefinitionsGrid" selectionMode="MULTI"
                   width="100%"
                   minHeight="20em"
                   dataContainer="decisionDefinitionsDc"
@@ -65,6 +66,7 @@
                 <action id="refresh" type="list_refresh"/>
                 <action id="deploy" type="control_deployDecisionDefinition" icon="ROCKET" text="msg://decisionDefinitionList.uploadDmnXml"/>
                 <action id="view" type="list_edit" visible="false"/>
+                <action id="excelExport" type="control_excelExport"/>
             </actions>
             <columns resizable="true">
                 <column property="name" autoWidth="true" flexGrow="1">

--- a/src/main/resources/io/flowset/control/view/decisioninstance/decision-instance-data-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/decisioninstance/decision-instance-data-list-view.xml
@@ -26,9 +26,10 @@
     <layout>
         <hbox id="buttonsPanel" classNames="buttons-panel">
             <button id="refreshButton" themeNames="success primary" action="decisionInstancesDataGrid.refreshAction"/>
+            <button id="excelExportButton" action="decisionInstancesDataGrid.excelExport"/>
             <simplePagination id="pagination" dataLoader="decisionInstancesDl"/>
         </hbox>
-        <dataGrid id="decisionInstancesDataGrid"
+        <dataGrid id="decisionInstancesDataGrid" selectionMode="MULTI"
                   width="100%"
                   minHeight="20em"
                   dataContainer="decisionInstancesDc"
@@ -36,6 +37,7 @@
             <actions>
                 <action id="refreshAction" type="list_refresh"/>
                 <action id="viewAction" type="list_edit" visible="false" text="msg:///actions.View"/>
+                <action id="excelExport" type="control_excelExport"/>
             </actions>
             <columns resizable="true">
                 <column property="decisionInstanceId" sortable="false">

--- a/src/main/resources/io/flowset/control/view/deploymentdata/deployment-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/deploymentdata/deployment-list-view.xml
@@ -54,6 +54,7 @@
         <hbox id="buttonsPanel" classNames="buttons-panel">
             <button id="refreshBtn" action="deploymentsDataGrid.refresh" themeNames="primary success"/>
             <button id="bulkRemoveBtn" action="deploymentsDataGrid.bulkRemove"/>
+            <button id="excelExportBtn" action="deploymentsDataGrid.excelExport"/>
             <simplePagination id="pagination" dataLoader="deploymentDatasDl"/>
         </hbox>
         <dataGrid id="deploymentsDataGrid"
@@ -67,6 +68,7 @@
                 <action id="bulkRemove" type="control_bulkDeleteDeployment" icon="TRASH"
                         actionVariant="DANGER"/>
                 <action id="view" type="list_edit" visible="false"/>
+                <action id="excelExport" type="control_excelExport"/>
             </actions>
             <columns resizable="true">
                 <column property="deploymentId" flexGrow="1">

--- a/src/main/resources/io/flowset/control/view/incidentdata/incident-data-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/incidentdata/incident-data-list-view.xml
@@ -27,6 +27,7 @@
         <hbox id="buttonsPanel" classNames="buttons-panel" alignItems="BASELINE">
             <button id="refreshBtn" action="incidentsDataGrid.refresh" themeNames="success primary"/>
             <button id="bulkRetryBtn" action="incidentsDataGrid.bulkRetry"/>
+            <button id="excelExportBtn" action="incidentsDataGrid.excelExport"/>
             <simplePagination id="pagination" dataLoader="incidentsDl"/>
         </hbox>
         <dataGrid id="incidentsDataGrid" classNames="incidents-data-grid"
@@ -37,6 +38,7 @@
                 <action id="refresh" type="list_refresh"/>
                 <action id="bulkRetry" type="control_bulkRetryIncident" icon="ROTATE_LEFT" text="msg:///actions.Retry"/>
                 <action id="view" type="list_edit" visible="false"/>
+                <action id="excelExport" type="control_excelExport"/>
             </actions>
             <columns resizable="true">
                 <column property="incidentId">

--- a/src/main/resources/io/flowset/control/view/processdefinition/process-definition-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/processdefinition/process-definition-list-view.xml
@@ -63,6 +63,12 @@
             <button id="bulkRemoveBtn" action="processDefinitionsGrid.bulkRemove"/>
             <button id="bulkActivateBtn" action="processDefinitionsGrid.bulkActivate"/>
             <button id="bulkSuspendBtn" action="processDefinitionsGrid.bulkSuspend"/>
+            <dropdownButton id="otherActions" icon="COG" dropdownIndicatorVisible="false" themeNames="icon"
+                            width="min-content" minWidth="auto">
+                <items>
+                   <actionItem id="excelExport" ref="processDefinitionsGrid.excelExport"/>
+                </items>
+            </dropdownButton>
             <simplePagination id="processDefinitionPagination" dataLoader="processDefinitionsDl"
                               alignSelf="END"/>
         </hbox>
@@ -82,6 +88,7 @@
                 <action id="bulkSuspend" type="control_bulkSuspendProcessDefinition" text="msg://processDefinitionList.suspend"
                         icon="PAUSE"/>
                 <action id="view" type="list_edit" visible="false"/>
+                <action id="excelExport" type="control_excelExport"/>
             </actions>
             <columns resizable="true">
                 <column property="name" flexGrow="2">

--- a/src/main/resources/io/flowset/control/view/processinstance/process-instance-list-view.xml
+++ b/src/main/resources/io/flowset/control/view/processinstance/process-instance-list-view.xml
@@ -29,6 +29,12 @@
             <button id="bulkTerminateBtn" action="processInstancesGrid.bulkTerminate" enabled="false"/>
             <button id="bulkSuspendBtn" action="processInstancesGrid.bulkSuspend" enabled="false"/>
             <button id="bulkActivateBtn" action="processInstancesGrid.bulkActivate" enabled="false"/>
+            <dropdownButton id="otherActions" icon="COG" dropdownIndicatorVisible="false" themeNames="icon"
+                            width="min-content" minWidth="auto">
+                <items>
+                    <actionItem id="excelExport" ref="processInstancesGrid.excelExport"/>
+                </items>
+            </dropdownButton>
             <simplePagination id="processInstancePagination" dataLoader="processInstancesDl"/>
         </hbox>
         <dataGrid id="processInstancesGrid"
@@ -41,6 +47,7 @@
                 <action id="bulkActivate" type="control_bulkActivateProcessInstance" icon="PLAY"/>
                 <action id="bulkSuspend" type="control_bulkSuspendProcessInstance" icon="PAUSE"/>
                 <action id="view" type="list_edit" visible="false"/>
+                <action id="excelExport" type="control_excelExport"/>
             </actions>
             <columns resizable="true">
                 <column property="id" flexGrow="1" frozen="true">

--- a/src/test/java/io/flowset/control/test_support/ui/view/batch/AllBatchListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/batch/AllBatchListView.java
@@ -32,19 +32,21 @@ public class AllBatchListView extends View<AllBatchListView> {
 
     public static final By ID_BUTTON_BY = byPath("root", "idBtn");
 
-    public static final int ACTIVE_ID_COLUMN_INDEX = 0;
-    public static final int ACTIVE_TYPE_COLUMN_INDEX = 1;
-    public static final int ACTIVE_START_TIME_COLUMN_INDEX = 2;
-    public static final int ACTIVE_STATE_COLUMN_INDEX = 3;
-    public static final int ACTIVE_FAILED_JOBS_COLUMN_INDEX = 4;
-    public static final int ACTIVE_TOTAL_JOBS_COLUMN_INDEX = 5;
-    public static final int ACTIVE_PROGRESS_COLUMN_INDEX = 6;
+    public static final int CHECKBOX_COLUMN_INDEX = 0;
 
-    public static final int COMPLETED_ID_COLUMN_INDEX = 0;
-    public static final int COMPLETED_TYPE_COLUMN_INDEX = 1;
-    public static final int COMPLETED_START_TIME_COLUMN_INDEX = 2;
-    public static final int COMPLETED_END_TIME_COLUMN_INDEX = 3;
-    public static final int COMPLETED_TOTAL_JOBS_COLUMN_INDEX = 4;
+    public static final int ACTIVE_ID_COLUMN_INDEX = 1;
+    public static final int ACTIVE_TYPE_COLUMN_INDEX = 2;
+    public static final int ACTIVE_START_TIME_COLUMN_INDEX = 3;
+    public static final int ACTIVE_STATE_COLUMN_INDEX = 4;
+    public static final int ACTIVE_FAILED_JOBS_COLUMN_INDEX = 5;
+    public static final int ACTIVE_TOTAL_JOBS_COLUMN_INDEX = 6;
+    public static final int ACTIVE_PROGRESS_COLUMN_INDEX = 7;
+
+    public static final int COMPLETED_ID_COLUMN_INDEX = 1;
+    public static final int COMPLETED_TYPE_COLUMN_INDEX = 2;
+    public static final int COMPLETED_START_TIME_COLUMN_INDEX = 3;
+    public static final int COMPLETED_END_TIME_COLUMN_INDEX = 4;
+    public static final int COMPLETED_TOTAL_JOBS_COLUMN_INDEX = 5;
 
     @TestComponent
     private TabSheet tabsheet;
@@ -52,11 +54,17 @@ public class AllBatchListView extends View<AllBatchListView> {
     @TestComponent(path = "refreshBtn")
     private Button refreshBtn;
 
+    @TestComponent(path = "excelExportBtn")
+    private Button excelExportBtn;
+
     @TestComponent(path = "activeBatchesDataGrid")
     private DataGrid activeBatchesDataGrid;
 
     @TestComponent(path = "completedBatchRefreshBtn")
     private Button completedBatchRefreshBtn;
+
+    @TestComponent(path = "completedBatchExcelExportBtn")
+    private Button completedBatchExcelExportBtn;
 
     @TestComponent(path = "completedBatchesDataGrid")
     private DataGrid completedBatchesDataGrid;

--- a/src/test/java/io/flowset/control/test_support/ui/view/decisiondefinition/DecisionDefinitionListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/decisiondefinition/DecisionDefinitionListView.java
@@ -33,15 +33,19 @@ public class DecisionDefinitionListView extends View<DecisionDefinitionListView>
 
     public static final By NAME_BUTTON_BY = byPath("root", "nameBtn");
     public static final By KEY_BUTTON_BY = byPath("root", "keyBtn");
-    public static final int NAME_COLUMN_INDEX = 0;
-    public static final int KEY_COLUMN_INDEX = 1;
-    public static final int VERSION_COLUMN_INDEX = 2;
+    public static final int CHECKBOX_COLUMN_INDEX = 0;
+    public static final int NAME_COLUMN_INDEX = 1;
+    public static final int KEY_COLUMN_INDEX = 2;
+    public static final int VERSION_COLUMN_INDEX = 3;
 
     @TestComponent(path = "refreshBtn")
     private Button refreshBtn;
 
     @TestComponent(path = "deployBtn")
     private Button deployBtn;
+
+    @TestComponent(path = "excelExportBtn")
+    private Button excelExportBtn;
 
     @TestComponent(path = "decisionDefinitionsGrid")
     private DataGrid decisionDefinitionsGrid;

--- a/src/test/java/io/flowset/control/test_support/ui/view/decisioninstance/DecisionInstanceListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/decisioninstance/DecisionInstanceListView.java
@@ -34,15 +34,19 @@ public class DecisionInstanceListView extends View<DecisionInstanceListView> {
     public static final By PROCESS_INSTANCE_BUTTON_BY = byPath("root", "processInstanceBtn");
     public static final By PROCESS_ID_BUTTON_BY = byPath("root", "processIdBtn");
 
-    public static final int DECISION_INSTANCE_ID_COLUMN_INDEX = 0;
-    public static final int DECISION_DEFINITION_ID_COLUMN_INDEX = 1;
-    public static final int EVALUATION_TIME_COLUMN_INDEX = 2;
-    public static final int PROCESS_INSTANCE_ID_COLUMN_INDEX = 3;
-    public static final int PROCESS_DEFINITION_ID_COLUMN_INDEX = 4;
-    public static final int ACTIVITY_ID_COLUMN_INDEX = 5;
+    public static final int CHECKBOX_COLUMN_INDEX = 0;
+    public static final int DECISION_INSTANCE_ID_COLUMN_INDEX = 1;
+    public static final int DECISION_DEFINITION_ID_COLUMN_INDEX = 2;
+    public static final int EVALUATION_TIME_COLUMN_INDEX = 3;
+    public static final int PROCESS_INSTANCE_ID_COLUMN_INDEX = 4;
+    public static final int PROCESS_DEFINITION_ID_COLUMN_INDEX = 5;
+    public static final int ACTIVITY_ID_COLUMN_INDEX = 6;
 
     @TestComponent(path = "refreshButton")
     private Button refreshButton;
+
+    @TestComponent(path = "excelExportButton")
+    private Button excelExportButton;
 
     @TestComponent(path = "decisionInstancesDataGrid")
     private DataGrid decisionInstancesDataGrid;

--- a/src/test/java/io/flowset/control/test_support/ui/view/deployment/DeploymentListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/deployment/DeploymentListView.java
@@ -60,6 +60,9 @@ public class DeploymentListView extends View<DeploymentListView> {
     @TestComponent(path = "bulkRemoveBtn")
     private Button bulkRemoveBtn;
 
+    @TestComponent(path = "excelExportBtn")
+    private Button excelExportBtn;
+
     @TestComponent(path = "pagination")
     private SimplePagination pagination;
 

--- a/src/test/java/io/flowset/control/test_support/ui/view/incident/IncidentListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/incident/IncidentListView.java
@@ -50,6 +50,9 @@ public class IncidentListView extends View<IncidentListView> {
     @TestComponent(path = "bulkRetryBtn")
     private Button bulkRetryButton;
 
+    @TestComponent(path = "excelExportBtn")
+    private Button excelExportButton;
+
     @TestComponent(path = "incidentsDataGrid")
     private DataGrid incidentsGrid;
 

--- a/src/test/java/io/flowset/control/test_support/ui/view/processdefinition/ProcessDefinitionListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/processdefinition/ProcessDefinitionListView.java
@@ -62,6 +62,9 @@ public class ProcessDefinitionListView extends View<ProcessDefinitionListView> {
     @TestComponent(path = "bulkSuspendBtn")
     private Button bulkSuspendBtn;
 
+    @TestComponent(path = "otherActions")
+    private DropdownButton otherActionsBtn;
+
     @TestComponent(path = "processDefinitionsGrid")
     private DataGrid processDefinitionsGrid;
 
@@ -146,6 +149,15 @@ public class ProcessDefinitionListView extends View<ProcessDefinitionListView> {
 
             waitUntilDataLoading();
         }
+    }
+
+    /**
+     * Opens the additional actions dropdown in the view toolbar.
+     *
+     * @return dropdown items with actions
+     */
+    public ElementsCollection openOtherActionsDropdown() {
+        return getVisibleDropdownItems(otherActionsBtn.getDelegate());
     }
 
     /**

--- a/src/test/java/io/flowset/control/test_support/ui/view/processinstance/ProcessInstanceListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/processinstance/ProcessInstanceListView.java
@@ -5,6 +5,7 @@
 
 package io.flowset.control.test_support.ui.view.processinstance;
 
+import com.codeborne.selenide.ElementsCollection;
 import io.flowset.control.test_support.ui.UiTestSupport;
 import io.flowset.control.test_support.ui.component.GridContextMenu;
 import io.flowset.control.test_support.ui.view.processinstance.detail.ProcessInstanceDetailView;
@@ -13,12 +14,14 @@ import io.jmix.masquerade.TestComponent;
 import io.jmix.masquerade.TestView;
 import io.jmix.masquerade.component.Button;
 import io.jmix.masquerade.component.DataGrid;
+import io.jmix.masquerade.component.DropdownButton;
 import io.jmix.masquerade.sys.View;
 import lombok.Getter;
 import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.Selenide.$;
 import static io.flowset.control.test_support.ui.UiTestSupport.getRowByCellContent;
+import static io.flowset.control.test_support.ui.UiTestSupport.getVisibleDropdownItems;
 import static io.flowset.control.test_support.ui.UiTestSupport.openGridContextMenu;
 import static io.jmix.masquerade.JConditions.VISIBLE;
 import static io.jmix.masquerade.JSelectors.byPath;
@@ -53,6 +56,9 @@ public class ProcessInstanceListView extends View<ProcessInstanceListView> {
     @TestComponent(path = "bulkActivateBtn")
     private Button bulkActivateBtn;
 
+    @TestComponent(path = "otherActions")
+    private DropdownButton otherActionsBtn;
+
     @TestComponent(path = "processInstancesGrid")
     private DataGrid processInstancesGrid;
 
@@ -70,6 +76,15 @@ public class ProcessInstanceListView extends View<ProcessInstanceListView> {
      */
     public GridContextMenu openInstancesGridContextActions() {
         return openGridContextMenu(processInstancesGrid);
+    }
+
+    /**
+     * Opens the Other actions dropdown button menu.
+     *
+     * @return collection of visible items in the dropdown
+     */
+    public ElementsCollection openOtherActionsDropdown() {
+        return getVisibleDropdownItems(otherActionsBtn.getDelegate());
     }
 
     /**

--- a/src/test/java/io/flowset/control/test_support/ui/view/usertask/AllTasksListView.java
+++ b/src/test/java/io/flowset/control/test_support/ui/view/usertask/AllTasksListView.java
@@ -59,6 +59,9 @@ public class AllTasksListView extends View<AllTasksListView> {
     @TestComponent(path = "reassignTaskBtn")
     private Button reassignTaskBtn;
 
+    @TestComponent(path = "excelExportBtn")
+    private Button excelExportBtn;
+
     @TestComponent(path = "tasksDataGrid")
     private DataGrid tasksDataGrid;
 

--- a/src/test/java/io/flowset/control/ui_autotest/batch/list/BatchListViewActiveTabActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/batch/list/BatchListViewActiveTabActionsUiTest.java
@@ -67,6 +67,26 @@ public class BatchListViewActiveTabActionsUiTest extends AbstractCamunda7UiTest 
     }
 
     @Test
+    @DisplayName("Excel action availability")
+    void givenLoggedInUser_whenOpenAllBatchListView_thenExcelActionAvailable() {
+        // given
+        MainView mainView = loginAsAdmin();
+
+        // when
+        AllBatchListView listView = mainView.openAllBatchListView();
+
+        // then
+        listView.getExcelExportBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openActiveBatchesGridContextMenu()
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action: data in data grid is updated")
     void givenOpenedListView_whenClickRefreshOnActiveTab_thenDataUpdated() {
         // given
@@ -106,7 +126,7 @@ public class BatchListViewActiveTabActionsUiTest extends AbstractCamunda7UiTest 
         listView.getRefreshBtn().shouldBe(VISIBLE);
 
         listView.openActiveBatchesGridContextMenu()
-                .shouldHave(visibleItems("Refresh"));
+                .shouldHave(visibleItems("Refresh", "Excel"));
     }
 
     @Test

--- a/src/test/java/io/flowset/control/ui_autotest/batch/list/BatchListViewCompletedTabActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/batch/list/BatchListViewCompletedTabActionsUiTest.java
@@ -66,6 +66,27 @@ public class BatchListViewCompletedTabActionsUiTest extends AbstractCamunda7UiTe
     }
 
     @Test
+    @DisplayName("Excel action availability on Completed tab")
+    void givenOpenedListView_whenSwitchToCompletedTab_thenExcelActionAvailable() {
+        // given
+        MainView mainView = loginAsAdmin();
+
+        // when
+        AllBatchListView listView = mainView.openAllBatchListView()
+                .selectCompletedTab();
+
+        // then
+        listView.getCompletedBatchExcelExportBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openCompletedBatchesGridContextMenu()
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action: data in Completed tab data grid is updated")
     void givenOpenedListView_whenClickRefreshOnCompletedTab_thenDataUpdated() {
         // given
@@ -116,7 +137,7 @@ public class BatchListViewCompletedTabActionsUiTest extends AbstractCamunda7UiTe
         listView.getCompletedBatchRefreshBtn().shouldBe(VISIBLE);
 
         listView.openCompletedBatchesGridContextMenu()
-                .shouldHave(visibleItems("Refresh"));
+                .shouldHave(visibleItems("Refresh", "Excel"));
     }
 
     @Test

--- a/src/test/java/io/flowset/control/ui_autotest/decisiondefinition/list/DecisionListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/decisiondefinition/list/DecisionListViewActionsUiTest.java
@@ -63,6 +63,29 @@ public class DecisionListViewActionsUiTest extends AbstractCamunda7UiTest {
     }
 
     @Test
+    @DisplayName("Excel action availability on decision definition list view")
+    void givenLoggedInUser_whenOpenDecisionDefinitionList_thenExcelActionEnabledRuleApplied() {
+        // given
+        applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/dmn/testDmn.dmn");
+
+        MainView mainView = loginAsAdmin();
+
+        // when
+        DecisionDefinitionListView listView = mainView.openDecisionDefinitionListView();
+
+        // then
+        listView.getExcelExportBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openDecisionGridContextActions()
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action reloads data in the data grid")
     void givenNewlyDeployedDecisionDefinition_whenClickRefresh_thenGridReloaded() {
         // given
@@ -190,6 +213,6 @@ public class DecisionListViewActionsUiTest extends AbstractCamunda7UiTest {
         listView.getDeployBtn().shouldBe(VISIBLE);
 
         listView.openDecisionGridContextActions()
-                .shouldHave(visibleItems("Refresh", "Deploy"));
+                .shouldHave(visibleItems("Refresh", "Deploy", "Excel"));
     }
 }

--- a/src/test/java/io/flowset/control/ui_autotest/decisioninstance/list/DecisionInstanceListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/decisioninstance/list/DecisionInstanceListViewActionsUiTest.java
@@ -71,6 +71,32 @@ public class DecisionInstanceListViewActionsUiTest extends AbstractCamunda7UiTes
     }
 
     @Test
+    @DisplayName("Excel action availability on decision instance list view")
+    void givenExistingDecisionInstance_whenOpenDecisionInstanceListView_thenExcelActionAvailable() {
+        // given
+        applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/dmn/testDmn.dmn")
+                .deploy("test_support/testProcessWithDecision.bpmn")
+                .startByKey("testProcessWithDecision");
+
+        MainView mainView = loginAsAdmin();
+
+        // when
+        DecisionInstanceListView listView = mainView.openDecisionInstanceListView();
+
+        // then
+        listView.getExcelExportButton()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openInstancesGridContextMenu()
+                .shouldBe(VISIBLE)
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action: data in data grid is updated")
     void givenOpenedListView_whenClickRefresh_thenDataUpdated() {
         // given
@@ -113,7 +139,7 @@ public class DecisionInstanceListViewActionsUiTest extends AbstractCamunda7UiTes
         listView.getRefreshButton().shouldBe(VISIBLE);
 
         listView.openInstancesGridContextMenu()
-                .shouldHave(visibleItems("Refresh"));
+                .shouldHave(visibleItems("Refresh", "Excel"));
     }
 
     @Test

--- a/src/test/java/io/flowset/control/ui_autotest/deployment/list/DeploymentListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/deployment/list/DeploymentListViewActionsUiTest.java
@@ -61,6 +61,29 @@ public class DeploymentListViewActionsUiTest extends AbstractCamunda7UiTest {
     }
 
     @Test
+    @DisplayName("Excel action availability on Deployment list view")
+    void givenExistingDeployment_whenOpenDeploymentList_thenExcelActionAvailable() {
+        // given
+        camundaRestTestHelper.createDeployment(camunda7, "test_support/vacationApproval.bpmn");
+
+        MainView mainView = loginAsAdmin();
+
+        // when
+        DeploymentListView listView = mainView.openDeploymentListView();
+
+        // then
+        listView.getExcelExportBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openDeploymentsGridContextMenu()
+                .shouldBe(VISIBLE)
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action: data in data grid is updated")
     void givenExistingDeployment_whenClickRefresh_thenGridReloaded() {
         // given
@@ -145,9 +168,10 @@ public class DeploymentListViewActionsUiTest extends AbstractCamunda7UiTest {
         // then
         listView.getRefreshBtn().shouldBe(VISIBLE);
         listView.getBulkRemoveBtn().shouldBe(VISIBLE);
+        listView.getExcelExportBtn().shouldBe(VISIBLE);
 
         listView.openDeploymentsGridContextMenu()
-                .shouldHave(visibleItems("Refresh", "Remove"));
+                .shouldHave(visibleItems("Refresh", "Remove", "Excel"));
     }
 
     @Test

--- a/src/test/java/io/flowset/control/ui_autotest/incident/IncidentListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/incident/IncidentListViewActionsUiTest.java
@@ -78,6 +78,31 @@ public class IncidentListViewActionsUiTest extends AbstractCamunda7UiTest {
     }
 
     @Test
+    @DisplayName("Excel action availability on incident list view")
+    void givenExistingIncident_whenOpenIncidentListView_thenExcelActionAvailable() {
+        // given
+        applicationContext.getBean(CamundaSampleDataManager.class, camunda7)
+                .deploy("test_support/testFailedJobIncident.bpmn")
+                .startByKey("testFailedJobIncident")
+                .waitJobsExecution();
+
+        MainView mainView = loginAsAdmin();
+
+        // when
+        IncidentListView listView = mainView.openIncidentListView();
+
+        // then
+        listView.getExcelExportButton()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openIncidentsGridContextMenu()
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action: data in data grid is updated")
     void givenOpenedListView_whenClickRefresh_thenDataUpdated() {
         // given
@@ -255,7 +280,7 @@ public class IncidentListViewActionsUiTest extends AbstractCamunda7UiTest {
         listView.getBulkRetryButton().shouldBe(VISIBLE);
 
         listView.openIncidentsGridContextMenu()
-                .shouldHave(visibleItems("Refresh", "Retry"));
+                .shouldHave(visibleItems("Refresh", "Retry", "Excel"));
     }
 
     @Test

--- a/src/test/java/io/flowset/control/ui_autotest/processdefinition/ProcessDefinitionListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/processdefinition/ProcessDefinitionListViewActionsUiTest.java
@@ -19,6 +19,7 @@ import io.flowset.control.test_support.ui.view.processdefinition.StartProcessWit
 import io.flowset.control.test_support.ui.view.processdefinition.detail.ProcessDefinitionDetailView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
@@ -26,6 +27,7 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
+import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.webdriver;
 import static com.codeborne.selenide.WebDriverConditions.urlContaining;
 import static io.flowset.control.test_support.ui.UiTestSupport.getVisibleDropdownItems;
@@ -61,6 +63,32 @@ public class ProcessDefinitionListViewActionsUiTest extends AbstractCamunda7UiTe
 
         listView.openProcessGridContextActions()
                 .find(text("Refresh"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
+    @DisplayName("Excel action availability on process list view")
+    void givenLoggedInUser_whenOpenProcessList_thenExcelActionAvailable() {
+        // given
+        MainView mainView = loginAsAdmin();
+
+        // when
+        ProcessDefinitionListView listView = mainView.openProcessListView();
+
+        // then
+        listView.getOtherActionsBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openOtherActionsDropdown()
+                .shouldHave(size(1))
+                .shouldHave(texts("Excel"));
+
+        $("body").sendKeys(Keys.ESCAPE);
+
+        listView.openProcessGridContextActions()
+                .find(text("Excel"))
                 .shouldBe(VISIBLE)
                 .shouldBe(ENABLED);
     }
@@ -293,6 +321,6 @@ public class ProcessDefinitionListViewActionsUiTest extends AbstractCamunda7UiTe
         listView.getBulkSuspendBtn().shouldBe(VISIBLE);
 
         listView.openProcessGridContextActions()
-                .shouldHave(visibleItems("Refresh", "Deploy", "Remove", "Activate", "Suspend"));
+                .shouldHave(visibleItems("Refresh", "Deploy", "Remove", "Activate", "Suspend", "Excel"));
     }
 }

--- a/src/test/java/io/flowset/control/ui_autotest/processinstance/list/ProcessInstanceListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/processinstance/list/ProcessInstanceListViewActionsUiTest.java
@@ -16,10 +16,14 @@ import io.flowset.control.test_support.ui.view.processinstance.ProcessInstanceLi
 import io.flowset.control.test_support.ui.view.processinstance.detail.ProcessInstanceDetailView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.webdriver;
 import static com.codeborne.selenide.WebDriverConditions.urlContaining;
 import static io.flowset.control.test_support.ui.condition.ControlCondition.*;
@@ -53,6 +57,32 @@ public class ProcessInstanceListViewActionsUiTest extends AbstractCamunda7UiTest
 
         listView.openInstancesGridContextActions()
                 .find(text("Refresh"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
+    @DisplayName("Excel action availability on process instance list view")
+    void givenLoggedInUser_whenOpenProcessInstanceList_thenExcelActionAvailable() {
+        // given
+        MainView mainView = loginAsAdmin();
+
+        // when
+        ProcessInstanceListView listView = mainView.openProcessInstanceListView();
+
+        // then
+        listView.getOtherActionsBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openOtherActionsDropdown()
+                .shouldHave(size(1))
+                .shouldHave(texts("Excel"));
+
+        $("body").sendKeys(Keys.ESCAPE);
+
+        listView.openInstancesGridContextActions()
+                .find(text("Excel"))
                 .shouldBe(VISIBLE)
                 .shouldBe(ENABLED);
     }
@@ -182,6 +212,6 @@ public class ProcessInstanceListViewActionsUiTest extends AbstractCamunda7UiTest
 
 
         listView.openInstancesGridContextActions()
-                .shouldHave(visibleItems("Refresh", "Terminate", "Activate", "Suspend"));
+                .shouldHave(visibleItems("Refresh", "Terminate", "Activate", "Suspend", "Excel"));
     }
 }

--- a/src/test/java/io/flowset/control/ui_autotest/usertask/list/UserTaskListViewActionsUiTest.java
+++ b/src/test/java/io/flowset/control/ui_autotest/usertask/list/UserTaskListViewActionsUiTest.java
@@ -56,6 +56,26 @@ public class UserTaskListViewActionsUiTest extends AbstractCamunda7UiTest {
     }
 
     @Test
+    @DisplayName("Excel action availability")
+    void givenLoggedInUser_whenOpenAllTasksView_thenExcelActionAvailable() {
+        // given
+        MainView mainView = loginAsAdmin();
+
+        // when
+        AllTasksListView listView = mainView.openUserTaskListView();
+
+        // then
+        listView.getExcelExportBtn()
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+
+        listView.openTasksGridContextMenu()
+                .find(text("Excel"))
+                .shouldBe(VISIBLE)
+                .shouldBe(ENABLED);
+    }
+
+    @Test
     @DisplayName("Refresh action: data in data grid is updated")
     void givenLoggedInUser_whenClickRefresh_thenDataUpdated() {
         // given
@@ -148,8 +168,9 @@ public class UserTaskListViewActionsUiTest extends AbstractCamunda7UiTest {
         listView.getRefreshBtn().shouldBe(VISIBLE);
         listView.getCompleteTaskBtn().shouldBe(VISIBLE);
         listView.getReassignTaskBtn().shouldBe(VISIBLE);
+        listView.getExcelExportBtn().shouldBe(VISIBLE);
 
         listView.openTasksGridContextMenu()
-                .shouldHave(visibleItems("Refresh", "Complete", "Reassign"));
+                .shouldHave(visibleItems("Refresh", "Complete", "Reassign", "Excel"));
     }
 }


### PR DESCRIPTION
1. Add action "Excel" on the list views opened from menu and loading data from the BPM engine:
- Processes
- Process instances
- Incidents
- User tasks
- Decisions
- Decision instances
- Deployments
- Batches - an action is added to each tab
2. By default, the Excel action is configured for exporting rows on the current page are selected in the data grid
3. Add UI auto-tests for checking availability of the Excel action